### PR TITLE
Fix reviewer validation

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -1288,7 +1288,20 @@ createChallenge.schema = {
             type: Joi.string().valid(_.values(ReviewOpportunityTypeEnum)).insensitive(),
             isAIReviewer: Joi.boolean().required(),
           })
-          .xor('isMemberReview', 'isAIReviewer')
+          // custom validator to check that either isAIReviewer or isMemberReview are true
+          .custom((value, helpers) => {
+            const isMember = value.isMemberReview === true;
+            const isAI = value.isAIReviewer === true;
+
+            if ((isMember ? 1 : 0) + (isAI ? 1 : 0) !== 1) {
+              // mimic Joi’s xor error wording
+              return helpers.error(
+                "object.xor",
+                { peers: ["isMemberReview", "isAIReviewer"] }
+              );
+            }
+            return value;
+          }, "exclusive true check")
       ),
       prizeSets: Joi.array().items(
         Joi.object().keys({


### PR DESCRIPTION
This fixes the validator for the reviewers array.
`xor` will check if both or neither of isAIReviewer  and isMemberReview **keys** are present. It will not look at the value.
I added a custom validator to look at the value and behave like the XOR validator.

before:
<img width="1518" height="873" alt="image" src="https://github.com/user-attachments/assets/60d92966-4379-455c-8a4d-3700004fc11f" />

after:
<img width="1147" height="1041" alt="image" src="https://github.com/user-attachments/assets/58c9d4aa-3a77-4a08-81ad-46788e575363" />

<img width="1258" height="1037" alt="image" src="https://github.com/user-attachments/assets/fd3a10b5-fa21-4200-885a-ba07a9309e02" />
