### PR TITLE
PM-2231 fix submission created at in api response

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -1733,7 +1733,7 @@ async function getChallengeStatistics(currentUser, id) {
     }
     // add submission
     map[submission.memberId].submissions.push({
-      created: submission.created,
+      created: submission.createdAt,
       score: _.get(
         _.find(submission.review || [], (r) => r.metadata),
         "score",


### PR DESCRIPTION
Submissions created at data is missing in api response for `/challenges/:challengeId/statistics`