### PR TITLE
PM-3926 ai screening phase

### DIFF
--- a/src/common/challenge-helper.js
+++ b/src/common/challenge-helper.js
@@ -15,6 +15,7 @@ const { ensureAcessibilityToModifiedGroups } = require("./group-helper");
 const { ChallengeStatusEnum } = require("@prisma/client");
 
 const SUBMISSION_PHASE_PRIORITY = ["Topgear Submission", "Topcoder Submission", "Submission"];
+const CHECKPOINT_SUBMISSION_PHASE_NAME = "Checkpoint Submission";
 
 class ChallengeHelper {
   /**
@@ -513,13 +514,13 @@ class ChallengeHelper {
 
   /**
    * Add AI Screening phase for challenges with AI reviewers.
-   * The AI screening phase is positioned after submission and allocated 4 hours by default.
+    * AI screening phases are positioned after submission/checkpoint submission and allocated 4 hours by default.
    * 
    * @param {Object} challenge challenge payload (mutated in-place)
    * @param {Object} prisma Prisma client
    * @param {Function} logDebugMessage optional logging function
    */
-  async addAIScreeningPhaseForChallengeCreation(challenge, prisma, logDebugMessage = () => {}) {
+  async addAIScreeningPhaseForChallenge(challenge, prisma, logDebugMessage = () => {}) {
     if (!challenge || !challenge.phases || !Array.isArray(challenge.reviewers)) {
       return;
     }
@@ -532,21 +533,24 @@ class ChallengeHelper {
       return;
     }
 
-    // Check if AI Screening phase already exists
-    const aiScreeningPhaseExists = challenge.phases.some((phase) => phase.name === "AI Screening");
-    if (aiScreeningPhaseExists) {
-      logDebugMessage("AI screening phase already exists, skipping creation");
-      return;
-    }
-
-    // Find the submission phase
+    // Find the regular submission phase
     const submissionPhaseName = SUBMISSION_PHASE_PRIORITY.find((name) =>
       challenge.phases.some((phase) => phase.name === name)
     );
 
-    if (!submissionPhaseName) {
+    const submissionPhase = submissionPhaseName
+      ? challenge.phases.find((phase) => phase.name === submissionPhaseName)
+      : null;
+
+    // Find the checkpoint submission phase (if present)
+    const checkpointSubmissionPhase = challenge.phases.find(
+      (phase) => phase.name === CHECKPOINT_SUBMISSION_PHASE_NAME
+    );
+
+    const sourceSubmissionPhases = _.compact([checkpointSubmissionPhase, submissionPhase]);
+    if (sourceSubmissionPhases.length === 0) {
       throw new errors.BadRequestError(
-        `Cannot add AI screening phase: no submission phase found in challenge`
+        `Cannot add AI screening phase: no submission/checkpoint submission phase found in challenge`
       );
     }
 
@@ -564,83 +568,88 @@ class ChallengeHelper {
 
     const [aiScreeningPhaseId, aiScreeningPhaseDef] = aiScreeningPhaseDefEntry;
 
-    // Find the submission phase in the challenge phases
-    const submissionPhase = challenge.phases.find((phase) => phase.name === submissionPhaseName);
-    if (!submissionPhase) {
-      throw new errors.BadRequestError(
-        `Cannot add AI screening phase: submission phase not found in challenge phases`
-      );
-    }
-
-    const reviewPhases = challenge.phases.filter(
-      (phase) =>
-        phase.name &&
-        phase.name.toLowerCase().includes("review") &&
-        phase.predecessor === submissionPhase.phaseId
-    );
-
-    // Create the AI Screening challenge phase
-    const aiScreeningPhase = {
-      phaseId: aiScreeningPhaseId,
-      name: "AI Screening",
-      description: aiScreeningPhaseDef.description,
-      duration: 14400, // 4 hours in seconds
-      isOpen: false,
-      predecessor: submissionPhase.phaseId, // predecessor is the submission phase's phaseId
-      constraints: [],
-      scheduledStartDate: undefined,
-      scheduledEndDate: undefined,
-      actualStartDate: undefined,
-      actualEndDate: undefined,
-    };
-
-    // Ensure AI Screening is ordered between submission and review phases in the phases array.
-    const firstReviewIndex = challenge.phases.indexOf(reviewPhases[0]);
-    logDebugMessage(`(firstReviewIndex=${firstReviewIndex})`)
-    if (firstReviewIndex >= 0) {
-      challenge.phases.splice(firstReviewIndex, 0, aiScreeningPhase);
-    } else {
-      challenge.phases.push(aiScreeningPhase);
-    }
-
-    // Re-link review phase(s) so they start after AI Screening instead of submission.
-    reviewPhases.forEach((phase) => {
-      phase.predecessor = aiScreeningPhase.phaseId;
-    });
-
-    // Recalculate phase dates to keep timeline in sync
-    if (submissionPhase.scheduledEndDate) {
-      aiScreeningPhase.scheduledStartDate = submissionPhase.scheduledEndDate;
-      aiScreeningPhase.scheduledEndDate = moment(aiScreeningPhase.scheduledStartDate)
-        .add(aiScreeningPhase.duration, "seconds")
-        .toDate()
-        .toISOString();
-      
-      logDebugMessage(
-        `AI screening phase dates calculated (start=${aiScreeningPhase.scheduledStartDate}, end=${aiScreeningPhase.scheduledEndDate})`
+    sourceSubmissionPhases.forEach((sourcePhase) => {
+      const aiScreeningPhaseExistsForSource = challenge.phases.some(
+        (phase) => phase.name === "AI Screening" && phase.predecessor === sourcePhase.phaseId
       );
 
-      // Update dates for review phases that now depend on AI Screening
+      if (aiScreeningPhaseExistsForSource) {
+        logDebugMessage(
+          `AI screening phase already exists for predecessor=${sourcePhase.phaseId}, skipping creation`
+        );
+        return;
+      }
+
+      const reviewPhases = challenge.phases.filter(
+        (phase) =>
+          phase.name &&
+          phase.name.toLowerCase().includes("review") &&
+          phase.predecessor === sourcePhase.phaseId
+      );
+
+      const aiScreeningPhase = {
+        phaseId: aiScreeningPhaseId,
+        name: "AI Screening",
+        description: aiScreeningPhaseDef.description,
+        duration: 14400, // 4 hours in seconds
+        isOpen: false,
+        predecessor: sourcePhase.phaseId,
+        constraints: [],
+        scheduledStartDate: undefined,
+        scheduledEndDate: undefined,
+        actualStartDate: undefined,
+        actualEndDate: undefined,
+      };
+
+      // Ensure AI Screening is ordered between source submission and review phases.
+      const firstReviewIndex = challenge.phases.indexOf(reviewPhases[0]);
+      const sourcePhaseIndex = challenge.phases.indexOf(sourcePhase);
+      if (firstReviewIndex >= 0) {
+        challenge.phases.splice(firstReviewIndex, 0, aiScreeningPhase);
+      } else if (sourcePhaseIndex >= 0) {
+        challenge.phases.splice(sourcePhaseIndex + 1, 0, aiScreeningPhase);
+      } else {
+        challenge.phases.push(aiScreeningPhase);
+      }
+
+      // Re-link review phase(s) so they start after AI Screening instead of source submission.
       reviewPhases.forEach((phase) => {
-        if (_.isNil(phase.actualStartDate)) {
-          phase.scheduledStartDate = aiScreeningPhase.scheduledEndDate;
-          if (phase.duration) {
-            phase.scheduledEndDate = moment(phase.scheduledStartDate)
-              .add(phase.duration, "seconds")
-              .toDate()
-              .toISOString();
-            
-            logDebugMessage(
-              `Updated ${phase.name} phase dates (start=${phase.scheduledStartDate}, end=${phase.scheduledEndDate})`
-            );
-          }
-        }
+        phase.predecessor = aiScreeningPhase.phaseId;
       });
-    }
 
-    logDebugMessage(
-      `AI screening phase added (phaseId=${aiScreeningPhase.phaseId}), updated ${reviewPhases.length} review predecessor(s)`
-    );
+      // Recalculate phase dates to keep timeline in sync
+      if (sourcePhase.scheduledEndDate) {
+        aiScreeningPhase.scheduledStartDate = sourcePhase.scheduledEndDate;
+        aiScreeningPhase.scheduledEndDate = moment(aiScreeningPhase.scheduledStartDate)
+          .add(aiScreeningPhase.duration, "seconds")
+          .toDate()
+          .toISOString();
+
+        logDebugMessage(
+          `AI screening phase dates calculated (predecessor=${sourcePhase.phaseId}, start=${aiScreeningPhase.scheduledStartDate}, end=${aiScreeningPhase.scheduledEndDate})`
+        );
+
+        reviewPhases.forEach((phase) => {
+          if (_.isNil(phase.actualStartDate)) {
+            phase.scheduledStartDate = aiScreeningPhase.scheduledEndDate;
+            if (phase.duration) {
+              phase.scheduledEndDate = moment(phase.scheduledStartDate)
+                .add(phase.duration, "seconds")
+                .toDate()
+                .toISOString();
+
+              logDebugMessage(
+                `Updated ${phase.name} phase dates (start=${phase.scheduledStartDate}, end=${phase.scheduledEndDate})`
+              );
+            }
+          }
+        });
+      }
+
+      logDebugMessage(
+        `AI screening phase added (phaseId=${aiScreeningPhase.phaseId}, predecessor=${sourcePhase.phaseId}), updated ${reviewPhases.length} review predecessor(s)`
+      );
+    });
   }
 
   async validateChallengeUpdateRequest(currentUser, challenge, data, challengeResources) {

--- a/src/common/challenge-helper.js
+++ b/src/common/challenge-helper.js
@@ -449,7 +449,8 @@ class ChallengeHelper {
       config.REVIEWS_API_URL || "https://api.topcoder-dev.com",
       "/"
     );
-    const url = `${reviewsApiBaseUrl}/v6/ai-review/configs`;
+    
+    const url = `${reviewsApiBaseUrl}/ai-review/configs`;
 
     for (const aiReviewConfig of aiReviewConfigs) {
       const payload = {
@@ -491,10 +492,10 @@ class ChallengeHelper {
   async getAIReviewTemplateById(templateId) {
     const token = await getM2MToken();
     const reviewsApiBaseUrl = _.trimEnd(
-      config.REVIEWS_API_URL || "https://api.topcoder-dev.com",
+      config.REVIEWS_API_URL || "http://localhost:3002",
       "/"
     );
-    const url = `${reviewsApiBaseUrl}/v6/ai-review/templates/${templateId}`;
+    const url = `${reviewsApiBaseUrl}/ai-review/templates/${templateId}`;
 
     try {
       const response = await axios.get(url, {

--- a/src/common/challenge-helper.js
+++ b/src/common/challenge-helper.js
@@ -450,7 +450,7 @@ class ChallengeHelper {
       "/"
     );
     
-    const url = `${reviewsApiBaseUrl}/ai-review/configs`;
+    const url = `${reviewsApiBaseUrl}/v6/ai-review/configs`;
 
     for (const aiReviewConfig of aiReviewConfigs) {
       const payload = {
@@ -492,10 +492,10 @@ class ChallengeHelper {
   async getAIReviewTemplateById(templateId) {
     const token = await getM2MToken();
     const reviewsApiBaseUrl = _.trimEnd(
-      config.REVIEWS_API_URL || "http://localhost:3002",
+      config.REVIEWS_API_URL || "https://api.topcoder-dev.com",
       "/"
     );
-    const url = `${reviewsApiBaseUrl}/ai-review/templates/${templateId}`;
+    const url = `${reviewsApiBaseUrl}/v6/ai-review/templates/${templateId}`;
 
     try {
       const response = await axios.get(url, {

--- a/src/common/challenge-helper.js
+++ b/src/common/challenge-helper.js
@@ -583,7 +583,7 @@ class ChallengeHelper {
       const reviewPhases = challenge.phases.filter(
         (phase) =>
           phase.name &&
-          phase.name.toLowerCase().includes("review") &&
+          (phase.name.toLowerCase().includes("review") || phase.name.toLowerCase().includes("screening")) &&
           phase.predecessor === sourcePhase.phaseId
       );
 
@@ -601,7 +601,7 @@ class ChallengeHelper {
         actualEndDate: undefined,
       };
 
-      // Ensure AI Screening is ordered between source submission and review phases.
+      // Ensure AI Screening is ordered between source submission and review (or screening) phases.
       const firstReviewIndex = challenge.phases.indexOf(reviewPhases[0]);
       const sourcePhaseIndex = challenge.phases.indexOf(sourcePhase);
       if (firstReviewIndex >= 0) {

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -1506,6 +1506,77 @@ async function getChallengeSubmissions(challengeId) {
 }
 
 /**
+ * Get AI review config for challenge.
+ * @param {String} challengeId the challenge id
+ * @returns {Promise<Object|null>} AI review config or null when not found
+ */
+async function getAIReviewConfigByChallengeId(challengeId) {
+  const token = await m2mHelper.getM2MToken();
+  const reviewsApiBaseUrl = _.trimEnd(
+    config.REVIEWS_API_URL || "https://api.topcoder-dev.com",
+    "/"
+  );
+
+  try {
+    const result = await axios.get(`${reviewsApiBaseUrl}/ai-review/configs/${challengeId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return result.data || null;
+  } catch (err) {
+    if (_.get(err, "response.status") === HttpStatus.NOT_FOUND) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Get all AI review decisions by AI review config id.
+ * @param {String} configId the AI review config id
+ * @returns {Promise<Array>} AI review decisions
+ */
+async function getAIReviewDecisionsByConfigId(configId) {
+  const token = await m2mHelper.getM2MToken();
+  const reviewsApiBaseUrl = _.trimEnd(
+    config.REVIEWS_API_URL || "https://api.topcoder-dev.com",
+    "/"
+  );
+
+  const allDecisions = [];
+  let page = 1;
+  while (true) {
+    const result = await axios.get(`${reviewsApiBaseUrl}/ai-review/decisions`, {
+      headers: { Authorization: `Bearer ${token}` },
+      params: {
+        configId,
+        page,
+        perPage: 100,
+      },
+    });
+
+    const pageData = _.get(result, "data.data", result.data || []);
+    const decisions = Array.isArray(pageData) ? pageData : [];
+    if (decisions.length === 0) {
+      break;
+    }
+
+    allDecisions.push(...decisions);
+
+    const totalPages = _.get(result, "data.meta.totalPages");
+    if (!totalPages) {
+      break;
+    }
+
+    page += 1;
+    if (page > totalPages) {
+      break;
+    }
+  }
+
+  return allDecisions;
+}
+
+/**
  * Get review summations for a challenge
  * @param {String} challengeId the challenge ID
  * @returns {Promise<Array>}
@@ -1829,6 +1900,8 @@ module.exports = {
   getProjectIdByRoundId,
   getGroupById,
   getChallengeSubmissions,
+  getAIReviewConfigByChallengeId,
+  getAIReviewDecisionsByConfigId,
   getReviewSummations,
   getMemberById,
   createSelfServiceProject,

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -1518,7 +1518,7 @@ async function getAIReviewConfigByChallengeId(challengeId) {
   );
 
   try {
-    const result = await axios.get(`${reviewsApiBaseUrl}/ai-review/configs/${challengeId}`, {
+    const result = await axios.get(`${reviewsApiBaseUrl}/v6/ai-review/configs/${challengeId}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     return result.data || null;
@@ -1545,7 +1545,7 @@ async function getAIReviewDecisionsByConfigId(configId) {
   const allDecisions = [];
   let page = 1;
   while (true) {
-    const result = await axios.get(`${reviewsApiBaseUrl}/ai-review/decisions`, {
+    const result = await axios.get(`${reviewsApiBaseUrl}/v6/ai-review/decisions`, {
       headers: { Authorization: `Bearer ${token}` },
       params: {
         configId,

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -1531,52 +1531,6 @@ async function getAIReviewConfigByChallengeId(challengeId) {
 }
 
 /**
- * Get all AI review decisions by AI review config id.
- * @param {String} configId the AI review config id
- * @returns {Promise<Array>} AI review decisions
- */
-async function getAIReviewDecisionsByConfigId(configId) {
-  const token = await m2mHelper.getM2MToken();
-  const reviewsApiBaseUrl = _.trimEnd(
-    config.REVIEWS_API_URL || "https://api.topcoder-dev.com",
-    "/"
-  );
-
-  const allDecisions = [];
-  let page = 1;
-  while (true) {
-    const result = await axios.get(`${reviewsApiBaseUrl}/v6/ai-review/decisions`, {
-      headers: { Authorization: `Bearer ${token}` },
-      params: {
-        configId,
-        page,
-        perPage: 100,
-      },
-    });
-
-    const pageData = _.get(result, "data.data", result.data || []);
-    const decisions = Array.isArray(pageData) ? pageData : [];
-    if (decisions.length === 0) {
-      break;
-    }
-
-    allDecisions.push(...decisions);
-
-    const totalPages = _.get(result, "data.meta.totalPages");
-    if (!totalPages) {
-      break;
-    }
-
-    page += 1;
-    if (page > totalPages) {
-      break;
-    }
-  }
-
-  return allDecisions;
-}
-
-/**
  * Get review summations for a challenge
  * @param {String} challengeId the challenge ID
  * @returns {Promise<Array>}
@@ -1901,7 +1855,6 @@ module.exports = {
   getGroupById,
   getChallengeSubmissions,
   getAIReviewConfigByChallengeId,
-  getAIReviewDecisionsByConfigId,
   getReviewSummations,
   getMemberById,
   createSelfServiceProject,

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -380,24 +380,41 @@ async function ensureChallengeHasAiReviewers(challengeId) {
 }
 
 async function ensureAIScreeningCanBeClosed(challengeId) {
+  logger.debug(`Validating AI Screening closure for challenge ${challengeId}`);
   await ensureChallengeHasAiReviewers(challengeId);
 
   const aiReviewConfig = await helper.getAIReviewConfigByChallengeId(challengeId);
   if (!aiReviewConfig || !aiReviewConfig.id) {
+    logger.debug(
+      `AI Screening closure blocked for challenge ${challengeId}: AI review configuration not found`
+    );
     throw new errors.BadRequestError(
       "Cannot close AI Screening phase because AI review configuration could not be fetched"
     );
   }
+
+  logger.debug(
+    `Found AI review configuration ${aiReviewConfig.id} for challenge ${challengeId}`
+  );
 
   const [submissions, decisions] = await Promise.all([
     helper.getChallengeSubmissions(challengeId),
     helper.getAIReviewDecisionsByConfigId(aiReviewConfig.id),
   ]);
 
+  logger.debug(
+    `AI Screening data for challenge ${challengeId}: submissions=${(submissions || []).length}, decisions=${
+      (decisions || []).length
+    }`
+  );
+
   const submissionIds = _.uniq(
     (submissions || []).map((submission) => extractSubmissionId(submission)).filter((id) => !!id)
   );
   if (submissionIds.length === 0) {
+    logger.debug(
+      `AI Screening closure allowed for challenge ${challengeId}: no submissions found`
+    );
     return;
   }
 
@@ -414,10 +431,15 @@ async function ensureAIScreeningCanBeClosed(challengeId) {
   );
 
   if (hasPendingDecision || missingFinalizedSubmissions.length > 0) {
+    logger.debug(
+      `AI Screening closure blocked for challenge ${challengeId}: hasPendingDecision=${hasPendingDecision}, missingFinalizedSubmissions=${missingFinalizedSubmissions.length}`
+    );
     throw new errors.BadRequestError(
       "Cannot close AI Screening phase because AI reviews are not complete"
     );
   }
+
+  logger.debug(`AI Screening closure allowed for challenge ${challengeId}: all reviews finalized`);
 }
 
 async function checkChallengeExists(challengeId) {

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -681,7 +681,7 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
     }
 
     if (String(closingPhaseName || "").toLowerCase() === "ai screening") {
-      await ensureAIScreeningCanBeClosed(challenge);
+      await ensureAIScreeningCanBeClosed(challengePhase.challengeId);
     }
 
     if (!("actualEndDate" in data) || _.isNil(data.actualEndDate)) {

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -353,6 +353,73 @@ async function hasPendingAppealResponsesForChallenge(challengeId) {
   return Number(count) > 0;
 }
 
+function extractSubmissionId(submission) {
+  const candidate =
+    _.get(submission, "id") ||
+    _.get(submission, "submissionId") ||
+    _.get(submission, "legacySubmissionId");
+  if (_.isNil(candidate)) {
+    return null;
+  }
+  const normalized = _.toString(candidate).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+async function ensureChallengeHasAiReviewers(challengeId) {
+  const reviewers = await prisma.challengeReviewer.findMany({
+    where: { challengeId, isMemberReview: false, aiWorkflowId: { not: null } },
+  });
+
+  const hasAIReviewers = Array.isArray(reviewers) && reviewers.length > 0;
+
+  if (!hasAIReviewers) {
+    throw new errors.BadRequestError(
+      `Challenge does not have any AI reviewers assigned`
+    );
+  }
+}
+
+async function ensureAIScreeningCanBeClosed(challengeId) {
+  await ensureChallengeHasAiReviewers(challengeId);
+
+  const aiReviewConfig = await helper.getAIReviewConfigByChallengeId(challengeId);
+  if (!aiReviewConfig || !aiReviewConfig.id) {
+    throw new errors.BadRequestError(
+      "Cannot close AI Screening phase because AI review configuration could not be fetched"
+    );
+  }
+
+  const [submissions, decisions] = await Promise.all([
+    helper.getChallengeSubmissions(challengeId),
+    helper.getAIReviewDecisionsByConfigId(aiReviewConfig.id),
+  ]);
+
+  const submissionIds = _.uniq(
+    (submissions || []).map((submission) => extractSubmissionId(submission)).filter((id) => !!id)
+  );
+  if (submissionIds.length === 0) {
+    return;
+  }
+
+  const finalizedDecisionSubmissionIds = new Set(
+    (decisions || [])
+      .filter((decision) => decision && decision.isFinal === true)
+      .map((decision) => extractSubmissionId(decision))
+      .filter((id) => !!id)
+  );
+
+  const hasPendingDecision = (decisions || []).some((decision) => decision && decision.isFinal !== true);
+  const missingFinalizedSubmissions = submissionIds.filter(
+    (submissionId) => !finalizedDecisionSubmissionIds.has(submissionId)
+  );
+
+  if (hasPendingDecision || missingFinalizedSubmissions.length > 0) {
+    throw new errors.BadRequestError(
+      "Cannot close AI Screening phase because AI reviews are not complete"
+    );
+  }
+}
+
 async function checkChallengeExists(challengeId) {
   const challenge = await prisma.challenge.findUnique({ where: { id: challengeId } });
   if (!challenge) {
@@ -612,6 +679,11 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
         "Appeals Response phase can't be closed because there are still appeals that haven't been responded to"
       );
     }
+
+    if (String(closingPhaseName || "").toLowerCase() === "ai screening") {
+      await ensureAIScreeningCanBeClosed(challenge);
+    }
+
     if (!("actualEndDate" in data) || _.isNil(data.actualEndDate)) {
       data.actualEndDate = new Date();
     }

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -397,10 +397,38 @@ async function ensureAIScreeningCanBeClosed(challengeId) {
     `Found AI review configuration ${aiReviewConfig.id} for challenge ${challengeId}`
   );
 
-  const [submissions, decisions] = await Promise.all([
-    helper.getChallengeSubmissions(challengeId),
-    helper.getAIReviewDecisionsByConfigId(aiReviewConfig.id),
-  ]);
+  const reviewPrisma = getReviewClient();
+  const reviewSchema = config.REVIEW_DB_SCHEMA;
+  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`);
+  const aiReviewDecisionTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecision"`);
+
+  let submissions;
+  let decisions;
+  try {
+    [submissions, decisions] = await Promise.all([
+      reviewPrisma.$queryRaw(
+        Prisma.sql`
+          SELECT "id", "legacySubmissionId"
+          FROM ${submissionTable}
+          WHERE "challengeId" = ${challengeId}
+            AND "status"::text <> 'DELETED'
+        `
+      ),
+      reviewPrisma.$queryRaw(
+        Prisma.sql`
+          SELECT "submissionId", "isFinal"
+          FROM ${aiReviewDecisionTable}
+          WHERE "configId" = ${aiReviewConfig.id}
+        `
+      ),
+    ]);
+  } catch (err) {
+    logger.error(
+      `Failed to fetch AI screening submissions/decisions for challenge ${challengeId}: ${err.message}`,
+      err
+    );
+    throw err;
+  }
 
   logger.debug(
     `AI Screening data for challenge ${challengeId}: submissions=${(submissions || []).length}, decisions=${

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -3998,7 +3998,7 @@ async function advancePhase(currentUser, challengeId, data) {
     data.operation === "close" &&
     normalizePhaseNameForComparison(data.phase) === AI_SCREENING_PHASE_NAME;
   if (isClosingAIScreening) {
-    await ensureAIScreeningCanBeClosed(challenge);
+    await ensureAIScreeningCanBeClosed(challenge.id);
   }
 
   const phaseAdvancerResult = await phaseAdvancer.advancePhase(

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -105,6 +105,70 @@ const REVIEW_PHASE_NAMES = Object.freeze([
 ]);
 const REVIEW_PHASE_NAME_SET = new Set(REVIEW_PHASE_NAMES);
 const REQUIRED_REVIEW_PHASE_NAME_SET = new Set([...REVIEW_PHASE_NAMES, "iterative review"]);
+const AI_SCREENING_PHASE_NAME = "ai screening";
+
+function normalizePhaseNameForComparison(phaseName) {
+  return _.toString(phaseName).replace(/-/g, " ").trim().toLowerCase();
+}
+
+function extractSubmissionId(submission) {
+  const candidate =
+    _.get(submission, "id") ||
+    _.get(submission, "submissionId") ||
+    _.get(submission, "legacySubmissionId");
+  if (_.isNil(candidate)) {
+    return null;
+  }
+  const normalized = _.toString(candidate).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+async function ensureAIScreeningCanBeClosed(challenge) {
+  const hasAIReviewers = Array.isArray(challenge.reviewers)
+    ? challenge.reviewers.some((reviewer) => !reviewer.isMemberReview && reviewer.aiWorkflowId)
+    : false;
+
+  if (!hasAIReviewers) {
+    return;
+  }
+
+  const aiReviewConfig = await helper.getAIReviewConfigByChallengeId(challenge.id);
+  if (!aiReviewConfig || !aiReviewConfig.id) {
+    throw new errors.BadRequestError(
+      "Cannot close AI Screening phase because AI review configuration could not be fetched"
+    );
+  }
+
+  const [submissions, decisions] = await Promise.all([
+    helper.getChallengeSubmissions(challenge.id),
+    helper.getAIReviewDecisionsByConfigId(aiReviewConfig.id),
+  ]);
+
+  const submissionIds = _.uniq(
+    (submissions || []).map((submission) => extractSubmissionId(submission)).filter((id) => !!id)
+  );
+  if (submissionIds.length === 0) {
+    return;
+  }
+
+  const finalizedDecisionSubmissionIds = new Set(
+    (decisions || [])
+      .filter((decision) => decision && decision.isFinal === true)
+      .map((decision) => extractSubmissionId(decision))
+      .filter((id) => !!id)
+  );
+
+  const hasPendingDecision = (decisions || []).some((decision) => decision && decision.isFinal !== true);
+  const missingFinalizedSubmissions = submissionIds.filter(
+    (submissionId) => !finalizedDecisionSubmissionIds.has(submissionId)
+  );
+
+  if (hasPendingDecision || missingFinalizedSubmissions.length > 0) {
+    throw new errors.BadRequestError(
+      "Cannot close AI Screening phase because AI reviews are not complete"
+    );
+  }
+}
 
 /**
  * Enrich skills data with full details from standardized skills API.
@@ -3986,6 +4050,13 @@ async function advancePhase(currentUser, challengeId, data) {
   }
   if (challenge.status !== ChallengeStatusEnum.ACTIVE) {
     throw new errors.BadRequestError(`Challenge with id: ${challengeId} is not in ACTIVE status.`);
+  }
+
+  const isClosingAIScreening =
+    data.operation === "close" &&
+    normalizePhaseNameForComparison(data.phase) === AI_SCREENING_PHASE_NAME;
+  if (isClosingAIScreening) {
+    await ensureAIScreeningCanBeClosed(challenge);
   }
 
   const phaseAdvancerResult = await phaseAdvancer.advancePhase(

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -2726,7 +2726,7 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
     logger.debug(`updateChallenge: checking if AI screening phase needs to be added (challengeId=${challengeId})`);
     const tempChallenge = { phases: phasesForUpdate || challenge.phases, reviewers: data.reviewers || challenge.reviewers };
     const debugLogForAI = (message) => logger.debug(`updateChallenge(AI screening): ${message} (challengeId=${challengeId})`);
-    await challengeHelper.addAIScreeningPhaseForChallengeCreation(
+    await challengeHelper.addAIScreeningPhaseForChallenge(
       tempChallenge,
       prisma,
       debugLogForAI,

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -34,6 +34,7 @@ const {
   PrizeSetTypeEnum,
   ReviewOpportunityTypeEnum,
 } = require("../common/prisma");
+const { ensureAIScreeningCanBeClosed } = require("./ChallengePhaseService");
 const prisma = getClient();
 
 // Provide aliases for friendlier sortBy query params
@@ -109,65 +110,6 @@ const AI_SCREENING_PHASE_NAME = "ai screening";
 
 function normalizePhaseNameForComparison(phaseName) {
   return _.toString(phaseName).replace(/-/g, " ").trim().toLowerCase();
-}
-
-function extractSubmissionId(submission) {
-  const candidate =
-    _.get(submission, "id") ||
-    _.get(submission, "submissionId") ||
-    _.get(submission, "legacySubmissionId");
-  if (_.isNil(candidate)) {
-    return null;
-  }
-  const normalized = _.toString(candidate).trim();
-  return normalized.length > 0 ? normalized : null;
-}
-
-async function ensureAIScreeningCanBeClosed(challenge) {
-  const hasAIReviewers = Array.isArray(challenge.reviewers)
-    ? challenge.reviewers.some((reviewer) => !reviewer.isMemberReview && reviewer.aiWorkflowId)
-    : false;
-
-  if (!hasAIReviewers) {
-    return;
-  }
-
-  const aiReviewConfig = await helper.getAIReviewConfigByChallengeId(challenge.id);
-  if (!aiReviewConfig || !aiReviewConfig.id) {
-    throw new errors.BadRequestError(
-      "Cannot close AI Screening phase because AI review configuration could not be fetched"
-    );
-  }
-
-  const [submissions, decisions] = await Promise.all([
-    helper.getChallengeSubmissions(challenge.id),
-    helper.getAIReviewDecisionsByConfigId(aiReviewConfig.id),
-  ]);
-
-  const submissionIds = _.uniq(
-    (submissions || []).map((submission) => extractSubmissionId(submission)).filter((id) => !!id)
-  );
-  if (submissionIds.length === 0) {
-    return;
-  }
-
-  const finalizedDecisionSubmissionIds = new Set(
-    (decisions || [])
-      .filter((decision) => decision && decision.isFinal === true)
-      .map((decision) => extractSubmissionId(decision))
-      .filter((id) => !!id)
-  );
-
-  const hasPendingDecision = (decisions || []).some((decision) => decision && decision.isFinal !== true);
-  const missingFinalizedSubmissions = submissionIds.filter(
-    (submissionId) => !finalizedDecisionSubmissionIds.has(submissionId)
-  );
-
-  if (hasPendingDecision || missingFinalizedSubmissions.length > 0) {
-    throw new errors.BadRequestError(
-      "Cannot close AI Screening phase because AI reviews are not complete"
-    );
-  }
 }
 
 /**


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of AI Screening phases in the challenge workflow. The changes ensure that AI Screening phases are correctly inserted after both submission and checkpoint submission phases, and add robust validation to prevent closing the AI Screening phase before all AI reviews are complete. Additionally, new helper utilities are introduced for fetching AI review configurations and validating AI Screening phase closure.

**Enhancements to AI Screening phase logic:**

- The AI Screening phase is now inserted after both regular and checkpoint submission phases, rather than only after the regular submission phase. The code ensures that multiple AI Screening phases are not created for the same predecessor, and that review phases are correctly linked to follow the AI Screening phase. Error handling is improved for cases where no submission phases are found.

**Validation before closing AI Screening phase:**

- New validation ensures that the AI Screening phase cannot be closed unless all AI reviews are finalized for all submissions. This includes checking for the presence of AI reviewers, fetching the relevant AI review configuration, and verifying that all submissions have a completed AI review decision. Attempts to close the phase prematurely will result in an error.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/challenge-api-v6/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
