### PR TITLE
PM-4318 move to next phase when manually closing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
                 - develop
                 - security
                 - PM-3351
-                - PM-3926_ai-screening-phase
+                - PM-4318_move-to-next-phase-when-manually-closing
 
       - "build-qa":
           context: org-global

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -898,8 +898,9 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
         id: challengePhase.id,
       },
     });
+    let scheduleExtended = false;
     if (shouldAttemptSuccessorRecalc) {
-      const scheduleExtended = dateIsAfter(
+      scheduleExtended = dateIsAfter(
         updatedPhase.scheduledEndDate,
         originalScheduledEndDate
       );
@@ -908,7 +909,11 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       }
     }
     if (isClosingPhase && !_.isNil(originalScheduledEndDate) && !_.isNil(updatedPhase.actualEndDate)) {
-      const scheduledEndTime = new Date(originalScheduledEndDate).getTime();
+      const shiftBaselineScheduledEndDate =
+        scheduleExtended && !_.isNil(updatedPhase.scheduledEndDate)
+          ? updatedPhase.scheduledEndDate
+          : originalScheduledEndDate;
+      const scheduledEndTime = new Date(shiftBaselineScheduledEndDate).getTime();
       const actualEndTime = new Date(updatedPhase.actualEndDate).getTime();
 
       if (Number.isFinite(scheduledEndTime) && Number.isFinite(actualEndTime)) {

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -154,6 +154,84 @@ async function recalculateDependentPhaseDates(tx, challengeId, predecessorPhase,
   }
 }
 
+async function shiftDependentPhaseDates(tx, challengeId, predecessorPhase, deltaMs, currentUserId) {
+  if (!predecessorPhase || !Number.isFinite(deltaMs) || deltaMs === 0) {
+    return;
+  }
+
+  const phases = await tx.challengePhase.findMany({
+    where: { challengeId },
+  });
+
+  const successorsByPredecessor = new Map();
+  for (const phase of phases) {
+    if (_.isNil(phase.predecessor)) {
+      continue;
+    }
+    const key = String(phase.predecessor);
+    if (!successorsByPredecessor.has(key)) {
+      successorsByPredecessor.set(key, []);
+    }
+    successorsByPredecessor.get(key).push(phase);
+  }
+
+  const queue = [predecessorPhase];
+  const visited = new Set();
+
+  while (queue.length > 0) {
+    const currentPhase = queue.shift();
+    const predecessorKeys = buildPhaseIdentifiers(currentPhase);
+
+    for (const predecessorKey of predecessorKeys) {
+      const successors = successorsByPredecessor.get(predecessorKey) || [];
+      for (const successor of successors) {
+        if (visited.has(successor.id)) {
+          continue;
+        }
+
+        let successorForQueue = successor;
+        if (_.isNil(successor.actualStartDate)) {
+          const scheduledStartTime = successor.scheduledStartDate
+            ? new Date(successor.scheduledStartDate).getTime()
+            : Number.NaN;
+          const scheduledEndTime = successor.scheduledEndDate
+            ? new Date(successor.scheduledEndDate).getTime()
+            : Number.NaN;
+
+          if (Number.isFinite(scheduledStartTime) && Number.isFinite(scheduledEndTime)) {
+            const desiredStartDate = new Date(scheduledStartTime + deltaMs);
+            const desiredEndDate = new Date(scheduledEndTime + deltaMs);
+            const startChanged = !datesAreSame(successor.scheduledStartDate, desiredStartDate);
+            const endChanged = !datesAreSame(successor.scheduledEndDate, desiredEndDate);
+
+            if (startChanged || endChanged) {
+              successorForQueue = await tx.challengePhase.update({
+                data: {
+                  scheduledStartDate: desiredStartDate,
+                  scheduledEndDate: desiredEndDate,
+                  updatedBy: currentUserId,
+                },
+                where: {
+                  id: successor.id,
+                },
+              });
+            } else {
+              successorForQueue = {
+                ...successor,
+                scheduledStartDate: successor.scheduledStartDate,
+                scheduledEndDate: successor.scheduledEndDate,
+              };
+            }
+          }
+        }
+
+        visited.add(successor.id);
+        queue.push(successorForQueue);
+      }
+    }
+  }
+}
+
 async function hasPendingScorecardsForPhase(challengePhaseId) {
   if (!config.REVIEW_DB_URL) {
     logger.debug(
@@ -882,6 +960,20 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       );
       if (scheduleExtended) {
         await recalculateDependentPhaseDates(tx, challengeId, updatedPhase, currentUserId);
+      }
+    }
+    if (isClosingPhase && !_.isNil(originalScheduledEndDate) && !_.isNil(updatedPhase.actualEndDate)) {
+      const scheduledEndTime = new Date(originalScheduledEndDate).getTime();
+      const actualEndTime = new Date(updatedPhase.actualEndDate).getTime();
+
+      if (Number.isFinite(scheduledEndTime) && Number.isFinite(actualEndTime)) {
+        await shiftDependentPhaseDates(
+          tx,
+          challengeId,
+          updatedPhase,
+          actualEndTime - scheduledEndTime,
+          currentUserId
+        );
       }
     }
     if (data["constraints"]) {

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -431,6 +431,48 @@ async function hasPendingAppealResponsesForChallenge(challengeId) {
   return Number(count) > 0;
 }
 
+async function hasPendingEscalationRequestsForChallenge(challengeId) {
+  if (!config.REVIEW_DB_URL) {
+    logger.debug(
+      `Skipping pending escalation request check for challenge ${challengeId} because REVIEW_DB_URL is not configured`
+    );
+    return false;
+  }
+
+  const reviewPrisma = getReviewClient();
+  const reviewSchema = config.REVIEW_DB_SCHEMA;
+  const escalationTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecisionEscalation"`);
+  const decisionTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecision"`);
+  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`);
+
+  let rows;
+  try {
+    rows = await reviewPrisma.$queryRaw(
+      Prisma.sql`
+        SELECT COUNT(DISTINCT arde."id")::int AS count
+        FROM ${escalationTable} arde
+        INNER JOIN ${decisionTable} ard ON ard."id" = arde."aiReviewDecisionId"
+        WHERE arde."status" = 'PENDING_APPROVAL'
+          AND EXISTS (
+            SELECT 1
+            FROM ${submissionTable} s
+            WHERE s."challengeId" = ${challengeId}
+              AND s."id" = ard."submissionId"
+          )
+      `
+    );
+  } catch (err) {
+    logger.error(
+      `Failed to check pending escalation requests for challenge ${challengeId}: ${err.message}`,
+      err
+    );
+    throw err;
+  }
+
+  const [{ count = 0 } = {}] = rows || [];
+  return Number(count) > 0;
+}
+
 async function checkChallengeExists(challengeId) {
   const challenge = await prisma.challenge.findUnique({ where: { id: challengeId } });
   if (!challenge) {
@@ -637,6 +679,17 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
   if (isOpeningPhase) {
     const phaseName = data.name || challengePhase.name;
     await ensureRequiredResourcesBeforeOpeningPhase(challengeId, phaseName);
+
+    // Check if this is the Appeals phase
+    const normalizedPhaseName = normalizePhaseName(phaseName);
+    if (normalizedPhaseName === "appeals") {
+      const hasPendingEscalations = await hasPendingEscalationRequestsForChallenge(challengeId);
+      if (hasPendingEscalations) {
+        throw new errors.BadRequestError(
+          "Cannot open Appeals phase because there are pending escalation requests that need to be resolved first"
+        );
+      }
+    }
   }
 
   if (data["scheduledStartDate"] || data["scheduledEndDate"]) {
@@ -675,6 +728,7 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
     "isOpen" in data && data["isOpen"] === true && !challengePhase.isOpen;
   if (isClosingPhase) {
     const closingPhaseName = data.name || challengePhase.name;
+    const normalizedClosingPhaseName = normalizePhaseName(closingPhaseName);
     const pendingScorecards = await hasPendingScorecardsForPhase(challengePhase.id);
     if (pendingScorecards) {
       const phaseName = closingPhaseName || "phase";
@@ -683,7 +737,15 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       );
     }
     if (
-      String(closingPhaseName || "").toLowerCase() === "appeals response" &&
+      normalizedClosingPhaseName === "review" &&
+      (await hasPendingEscalationRequestsForChallenge(challengePhase.challengeId))
+    ) {
+      throw new errors.BadRequestError(
+        "Cannot close Review phase because there are pending escalation requests that need to be resolved first"
+      );
+    }
+    if (
+      normalizedClosingPhaseName === "appeals response" &&
       (await hasPendingAppealResponsesForChallenge(challengePhase.challengeId))
     ) {
       throw new errors.BadRequestError(
@@ -691,7 +753,7 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       );
     }
 
-    if (String(closingPhaseName || "").toLowerCase() === "ai screening") {
+    if (normalizedClosingPhaseName === "ai screening") {
       await ensureAIScreeningCanBeClosed(challengePhase.challengeId);
     }
 

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -11,7 +11,7 @@ const logger = require("../common/logger");
 const errors = require("../common/errors");
 const constants = require("../../app-constants");
 const { getReviewClient } = require("../common/review-prisma");
-const { indexChallengeAndPostToKafka } = require("./ChallengeService");
+const { indexChallengeAndPostToKafka, ensureAIScreeningCanBeClosed } = require("./ChallengeService");
 
 const { getClient } = require("../common/prisma");
 const prisma = getClient();
@@ -429,123 +429,6 @@ async function hasPendingAppealResponsesForChallenge(challengeId) {
 
   const [{ count = 0 } = {}] = rows || [];
   return Number(count) > 0;
-}
-
-function extractSubmissionId(submission) {
-  const candidate =
-    _.get(submission, "id") ||
-    _.get(submission, "submissionId") ||
-    _.get(submission, "legacySubmissionId");
-  if (_.isNil(candidate)) {
-    return null;
-  }
-  const normalized = _.toString(candidate).trim();
-  return normalized.length > 0 ? normalized : null;
-}
-
-async function ensureChallengeHasAiReviewers(challengeId) {
-  const reviewers = await prisma.challengeReviewer.findMany({
-    where: { challengeId, isMemberReview: false, aiWorkflowId: { not: null } },
-  });
-
-  const hasAIReviewers = Array.isArray(reviewers) && reviewers.length > 0;
-
-  if (!hasAIReviewers) {
-    throw new errors.BadRequestError(
-      `Challenge does not have any AI reviewers assigned`
-    );
-  }
-}
-
-async function ensureAIScreeningCanBeClosed(challengeId) {
-  logger.debug(`Validating AI Screening closure for challenge ${challengeId}`);
-  await ensureChallengeHasAiReviewers(challengeId);
-
-  const aiReviewConfig = await helper.getAIReviewConfigByChallengeId(challengeId);
-  if (!aiReviewConfig || !aiReviewConfig.id) {
-    logger.debug(
-      `AI Screening closure blocked for challenge ${challengeId}: AI review configuration not found`
-    );
-    throw new errors.BadRequestError(
-      "Cannot close AI Screening phase because AI review configuration could not be fetched"
-    );
-  }
-
-  logger.debug(
-    `Found AI review configuration ${aiReviewConfig.id} for challenge ${challengeId}`
-  );
-
-  const reviewPrisma = getReviewClient();
-  const reviewSchema = config.REVIEW_DB_SCHEMA;
-  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`);
-  const aiReviewDecisionTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecision"`);
-
-  let submissions;
-  let decisions;
-  try {
-    [submissions, decisions] = await Promise.all([
-      reviewPrisma.$queryRaw(
-        Prisma.sql`
-          SELECT "id", "legacySubmissionId"
-          FROM ${submissionTable}
-          WHERE "challengeId" = ${challengeId}
-            AND "status"::text <> 'DELETED'
-        `
-      ),
-      reviewPrisma.$queryRaw(
-        Prisma.sql`
-          SELECT "submissionId", "isFinal"
-          FROM ${aiReviewDecisionTable}
-          WHERE "configId" = ${aiReviewConfig.id}
-        `
-      ),
-    ]);
-  } catch (err) {
-    logger.error(
-      `Failed to fetch AI screening submissions/decisions for challenge ${challengeId}: ${err.message}`,
-      err
-    );
-    throw err;
-  }
-
-  logger.debug(
-    `AI Screening data for challenge ${challengeId}: submissions=${(submissions || []).length}, decisions=${
-      (decisions || []).length
-    }`
-  );
-
-  const submissionIds = _.uniq(
-    (submissions || []).map((submission) => extractSubmissionId(submission)).filter((id) => !!id)
-  );
-  if (submissionIds.length === 0) {
-    logger.debug(
-      `AI Screening closure allowed for challenge ${challengeId}: no submissions found`
-    );
-    return;
-  }
-
-  const finalizedDecisionSubmissionIds = new Set(
-    (decisions || [])
-      .filter((decision) => decision && decision.isFinal === true)
-      .map((decision) => extractSubmissionId(decision))
-      .filter((id) => !!id)
-  );
-
-  const hasPendingDecision = (decisions || []).some((decision) => decision && decision.isFinal !== true);
-  const missingFinalizedSubmissions = submissionIds.filter(
-    (submissionId) => !finalizedDecisionSubmissionIds.has(submissionId)
-  );
-
-  if (hasPendingDecision || missingFinalizedSubmissions.length > 0) {
-    logger.debug(
-      `AI Screening closure blocked for challenge ${challengeId}: hasPendingDecision=${hasPendingDecision}, missingFinalizedSubmissions=${missingFinalizedSubmissions.length}`
-    );
-    throw new errors.BadRequestError(
-      "Cannot close AI Screening phase because AI reviews are not complete"
-    );
-  }
-
-  logger.debug(`AI Screening closure allowed for challenge ${challengeId}: all reviews finalized`);
 }
 
 async function checkChallengeExists(challengeId) {

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -34,7 +34,6 @@ const {
   PrizeSetTypeEnum,
   ReviewOpportunityTypeEnum,
 } = require("../common/prisma");
-const { ensureAIScreeningCanBeClosed } = require("./ChallengePhaseService");
 const prisma = getClient();
 
 // Provide aliases for friendlier sortBy query params
@@ -110,6 +109,123 @@ const AI_SCREENING_PHASE_NAME = "ai screening";
 
 function normalizePhaseNameForComparison(phaseName) {
   return _.toString(phaseName).replace(/-/g, " ").trim().toLowerCase();
+}
+
+function extractSubmissionId(submission) {
+  const candidate =
+    _.get(submission, "id") ||
+    _.get(submission, "submissionId") ||
+    _.get(submission, "legacySubmissionId");
+  if (_.isNil(candidate)) {
+    return null;
+  }
+  const normalized = _.toString(candidate).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+async function ensureChallengeHasAiReviewers(challengeId) {
+  const reviewers = await prisma.challengeReviewer.findMany({
+    where: { challengeId, isMemberReview: false, aiWorkflowId: { not: null } },
+  });
+
+  const hasAIReviewers = Array.isArray(reviewers) && reviewers.length > 0;
+
+  if (!hasAIReviewers) {
+    throw new errors.BadRequestError(
+      `Challenge does not have any AI reviewers assigned`
+    );
+  }
+}
+
+async function ensureAIScreeningCanBeClosed(challengeId) {
+  logger.debug(`Validating AI Screening closure for challenge ${challengeId}`);
+  await ensureChallengeHasAiReviewers(challengeId);
+
+  const aiReviewConfig = await helper.getAIReviewConfigByChallengeId(challengeId);
+  if (!aiReviewConfig || !aiReviewConfig.id) {
+    logger.debug(
+      `AI Screening closure blocked for challenge ${challengeId}: AI review configuration not found`
+    );
+    throw new errors.BadRequestError(
+      "Cannot close AI Screening phase because AI review configuration could not be fetched"
+    );
+  }
+
+  logger.debug(
+    `Found AI review configuration ${aiReviewConfig.id} for challenge ${challengeId}`
+  );
+
+  const reviewPrisma = getReviewClient();
+  const reviewSchema = config.REVIEW_DB_SCHEMA;
+  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`);
+  const aiReviewDecisionTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecision"`);
+
+  let submissions;
+  let decisions;
+  try {
+    [submissions, decisions] = await Promise.all([
+      reviewPrisma.$queryRaw(
+        Prisma.sql`
+          SELECT "id", "legacySubmissionId"
+          FROM ${submissionTable}
+          WHERE "challengeId" = ${challengeId}
+            AND "status"::text <> 'DELETED'
+        `
+      ),
+      reviewPrisma.$queryRaw(
+        Prisma.sql`
+          SELECT "submissionId", "isFinal"
+          FROM ${aiReviewDecisionTable}
+          WHERE "configId" = ${aiReviewConfig.id}
+        `
+      ),
+    ]);
+  } catch (err) {
+    logger.error(
+      `Failed to fetch AI screening submissions/decisions for challenge ${challengeId}: ${err.message}`,
+      err
+    );
+    throw err;
+  }
+
+  logger.debug(
+    `AI Screening data for challenge ${challengeId}: submissions=${(submissions || []).length}, decisions=${
+      (decisions || []).length
+    }`
+  );
+
+  const submissionIds = _.uniq(
+    (submissions || []).map((submission) => extractSubmissionId(submission)).filter((id) => !!id)
+  );
+  if (submissionIds.length === 0) {
+    logger.debug(
+      `AI Screening closure allowed for challenge ${challengeId}: no submissions found`
+    );
+    return;
+  }
+
+  const finalizedDecisionSubmissionIds = new Set(
+    (decisions || [])
+      .filter((decision) => decision && decision.isFinal === true)
+      .map((decision) => extractSubmissionId(decision))
+      .filter((id) => !!id)
+  );
+
+  const hasPendingDecision = (decisions || []).some((decision) => decision && decision.isFinal !== true);
+  const missingFinalizedSubmissions = submissionIds.filter(
+    (submissionId) => !finalizedDecisionSubmissionIds.has(submissionId)
+  );
+
+  if (hasPendingDecision || missingFinalizedSubmissions.length > 0) {
+    logger.debug(
+      `AI Screening closure blocked for challenge ${challengeId}: hasPendingDecision=${hasPendingDecision}, missingFinalizedSubmissions=${missingFinalizedSubmissions.length}`
+    );
+    throw new errors.BadRequestError(
+      "Cannot close AI Screening phase because AI reviews are not complete"
+    );
+  }
+
+  logger.debug(`AI Screening closure allowed for challenge ${challengeId}: all reviews finalized`);
 }
 
 /**

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -4382,6 +4382,7 @@ module.exports = {
   getDefaultReviewers,
   setDefaultReviewers,
   indexChallengeAndPostToKafka,
+  ensureAIScreeningCanBeClosed,
 };
 
 logger.buildService(module.exports);

--- a/test/unit/ChallengePhaseService.test.js
+++ b/test/unit/ChallengePhaseService.test.js
@@ -227,6 +227,90 @@ describe('challenge phase service unit tests', () => {
       actualEndMs.should.be.at.most(after.getTime())
     })
 
+    it('partially update challenge phase - closing shifts successor schedules to actual end date', async () => {
+      const aiScreeningTemplateId = uuid()
+      const aiScreeningPhaseId = uuid()
+      const submissionStartDate = new Date('2025-03-01T00:00:00.000Z')
+      const submissionScheduledEndDate = new Date('2025-03-03T00:00:00.000Z')
+      const aiScreeningScheduledStartDate = new Date('2025-03-03T00:00:00.000Z')
+      const aiScreeningScheduledEndDate = new Date('2025-03-04T00:00:00.000Z')
+
+      await prisma.phase.create({
+        data: {
+          id: aiScreeningTemplateId,
+          name: `AI Screening ${Date.now()}`,
+          description: 'ai screening test phase',
+          isOpen: true,
+          duration: 86400,
+          createdBy: 'admin',
+          updatedBy: 'admin'
+        }
+      })
+
+      await prisma.challengePhase.update({
+        where: { id: data.challengePhase2Id },
+        data: {
+          isOpen: true,
+          actualStartDate: submissionStartDate,
+          actualEndDate: null,
+          scheduledStartDate: submissionStartDate,
+          scheduledEndDate: submissionScheduledEndDate
+        }
+      })
+
+      await prisma.challengePhase.create({
+        data: {
+          id: aiScreeningPhaseId,
+          challengeId: data.challenge.id,
+          phaseId: aiScreeningTemplateId,
+          name: 'AI Screening',
+          duration: 86400,
+          predecessor: data.challengePhase2Id,
+          scheduledStartDate: aiScreeningScheduledStartDate,
+          scheduledEndDate: aiScreeningScheduledEndDate,
+          createdBy: 'admin',
+          updatedBy: 'admin'
+        }
+      })
+
+      try {
+        const before = new Date()
+        const challengePhase = await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase2Id,
+          {
+            isOpen: false
+          }
+        )
+        const after = new Date()
+
+        const successorPhase = await prisma.challengePhase.findUnique({
+          where: { id: aiScreeningPhaseId }
+        })
+
+        should.equal(challengePhase.isOpen, false)
+        should.exist(successorPhase)
+
+        const actualEndMs = new Date(challengePhase.actualEndDate).getTime()
+        const successorStartMs = new Date(successorPhase.scheduledStartDate).getTime()
+        const successorEndMs = new Date(successorPhase.scheduledEndDate).getTime()
+        const aiScreeningDurationMs = aiScreeningScheduledEndDate.getTime() - aiScreeningScheduledStartDate.getTime()
+
+        actualEndMs.should.be.at.least(before.getTime())
+        actualEndMs.should.be.at.most(after.getTime())
+        successorStartMs.should.equal(actualEndMs)
+        successorEndMs.should.equal(actualEndMs + aiScreeningDurationMs)
+      } finally {
+        await prisma.challengePhase.delete({
+          where: { id: aiScreeningPhaseId }
+        })
+        await prisma.phase.delete({
+          where: { id: aiScreeningTemplateId }
+        })
+      }
+    })
+
     it('partially update challenge phase - reopening clears actual end date and sets start date', async () => {
       const previousEndDate = new Date()
       await prisma.challengePhase.update({


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-4318 - When submission phase is manually closed, the AI screening phase doesn't get opened even if all AI reviews are completed

Make sure phases are recalculated and autopilot is advancing phases when user intervenes in timeline

**Challenge Phase Scheduling Improvements:**

- Added a new function, `shiftDependentPhaseDates`, to `ChallengePhaseService.js` that shifts the scheduled start and end dates of all successor phases when a phase is closed with an actual end date different from its scheduled end date. This ensures phase timelines remain consistent when phases are closed early or late.
- Updated `partiallyUpdateChallengePhase` to call `shiftDependentPhaseDates` when closing a phase, applying the time delta to all dependent phases.
- Added a comprehensive unit test to verify that closing a phase shifts the scheduled dates of its successors to match the actual closure time.

**AI Screening Phase Closure Logic Refactor:**

- Moved `extractSubmissionId`, `ensureChallengeHasAiReviewers`, and `ensureAIScreeningCanBeClosed` from `ChallengePhaseService.js` to `ChallengeService.js` for better separation of concerns and to avoid circular dependencies. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/challenge-api-v6/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
