### PR TITLE
PM-4478 add ai screening phase when editing after launch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
             branches:
               only:
                 - develop
-                - PM-4318_move-to-next-phase-when-manually-closing
+                - PM-4478_add-ai-screening-phase-when-editing-after-launch
                 - review-context
 
       - "build-qa":

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -2835,8 +2835,29 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
     phasesUpdated = true;
     phasesForUpdate = _.cloneDeep(data.phases);
   }
-  // Add AI screening phase if AI reviewers are assigned and challenge is being activated
-  if (isStatusChangingToActive) {
+  const hasAIReviewers = (reviewers) =>
+    Array.isArray(reviewers) &&
+    reviewers.some(
+      (reviewer) =>
+        reviewer &&
+        reviewer.isMemberReview === false &&
+        !_.isNil(reviewer.aiWorkflowId) &&
+        _.toString(reviewer.aiWorkflowId).trim() !== "",
+    );
+
+  const hadAIReviewersBeforeUpdate = hasAIReviewers(challenge.reviewers);
+  const hasAIReviewersAfterUpdate = hasAIReviewers(
+    !_.isNil(data.reviewers) ? data.reviewers : challenge.reviewers,
+  );
+  const isActiveWithNewAIReviewers =
+    challenge.status === ChallengeStatusEnum.ACTIVE &&
+    !hadAIReviewersBeforeUpdate &&
+    hasAIReviewersAfterUpdate;
+  const shouldEnsureAIScreeningPhase = isStatusChangingToActive || isActiveWithNewAIReviewers;
+
+  // Add AI screening phase when activating a challenge, or when AI reviewers are newly added
+  // to an already ACTIVE challenge.
+  if (shouldEnsureAIScreeningPhase) {
     logger.debug(
       `updateChallenge: checking if AI screening phase needs to be added (challengeId=${challengeId})`,
     );


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-4478 - The AI Screening phase is not displayed if the AI Review is added to the challenge after launch.

- Updated `updateChallenge` in `src/services/ChallengeService.js` to add the AI screening phase when either (a) a challenge is being activated, or (b) AI reviewers are newly assigned to an already ACTIVE challenge, by checking the before/after state of reviewers and status.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/challenge-api-v6/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
