### PR TITLE
PM-4478 add ai screening phase when editing after launch

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -2874,8 +2874,8 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
       `updateChallenge: checking if AI screening phase needs to be added (challengeId=${challengeId})`,
     );
     const tempChallenge = {
-      phases: phasesForUpdate || challenge.phases,
-      reviewers: data.reviewers || challenge.reviewers,
+      phases: _.cloneDeep(phasesForUpdate || challenge.phases),
+      reviewers: _.cloneDeep(data.reviewers || challenge.reviewers),
     };
     logger.debug(
       `updateChallenge: tempChallenge preview reviewers=${JSON.stringify(

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -2849,11 +2849,23 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
   const hasAIReviewersAfterUpdate = hasAIReviewers(
     !_.isNil(data.reviewers) ? data.reviewers : challenge.reviewers,
   );
+  logger.debug(
+    `updateChallenge: AI reviewers - before=${hadAIReviewersBeforeUpdate}, after=${hasAIReviewersAfterUpdate}`,
+  );
+  logger.debug(
+    `updateChallenge: reviewersPayloadPreview=${JSON.stringify(
+      (!_.isNil(data.reviewers) ? data.reviewers : challenge.reviewers) || [],
+    ).slice(0, 200)}`,
+  );
   const isActiveWithNewAIReviewers =
     challenge.status === ChallengeStatusEnum.ACTIVE &&
     !hadAIReviewersBeforeUpdate &&
     hasAIReviewersAfterUpdate;
+  logger.debug(`updateChallenge: isActiveWithNewAIReviewers=${isActiveWithNewAIReviewers}`);
   const shouldEnsureAIScreeningPhase = isStatusChangingToActive || isActiveWithNewAIReviewers;
+  logger.debug(
+    `updateChallenge: shouldEnsureAIScreeningPhase=${shouldEnsureAIScreeningPhase} isStatusChangingToActive=${isStatusChangingToActive}`,
+  );
 
   // Add AI screening phase when activating a challenge, or when AI reviewers are newly added
   // to an already ACTIVE challenge.
@@ -2865,9 +2877,19 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
       phases: phasesForUpdate || challenge.phases,
       reviewers: data.reviewers || challenge.reviewers,
     };
+    logger.debug(
+      `updateChallenge: tempChallenge preview reviewers=${JSON.stringify(
+        tempChallenge.reviewers || [],
+      ).slice(0, 200)} phasesCount=${(tempChallenge.phases || []).length}`,
+    );
     const debugLogForAI = (message) =>
       logger.debug(`updateChallenge(AI screening): ${message} (challengeId=${challengeId})`);
     await challengeHelper.addAIScreeningPhaseForChallenge(tempChallenge, prisma, debugLogForAI);
+    logger.info(
+      `updateChallenge: AI screening phase ensured (challengeId=${challengeId}) resultingPhases=${(
+        tempChallenge.phases || []
+      ).length}`,
+    );
     // Update phasesForUpdate with the updated phases after AI screening addition
     phasesForUpdate = tempChallenge.phases;
     phasesUpdated = true;


### PR DESCRIPTION
- added some more debugging logs and fixed 
- when preparing a temporary challenge object for AI screening phase logic, added deep cloning of `phases` and `reviewers` to avoid side effects, and included debug logs with previews of the reviewers and phase counts.
