### PR TITLE
PM-4686: block challenge activation for invalid billing accounts

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -58,6 +58,8 @@ module.exports = {
   CUSTOMER_PAYMENTS_URL:
     process.env.CUSTOMER_PAYMENTS_URL || "https://api.topcoder-dev.com/v5/customer-payments",
   FINANCE_API_URL: process.env.FINANCE_API_URL || "http://localhost:8080",
+  BILLING_ACCOUNTS_API_URL:
+    process.env.BILLING_ACCOUNTS_API_URL || "http://localhost:4000/v6/billing-accounts",
   CHALLENGE_MIGRATION_APP_URL:
     process.env.CHALLENGE_MIGRATION_APP_URL || "https://api.topcoder.com/v5/challenge-migration",
   // copilot resource role ids allowed to upload attachment

--- a/src/common/project-helper.js
+++ b/src/common/project-helper.js
@@ -33,6 +33,64 @@ function normalizeBillingMarkup(rawMarkup) {
   return markup > 1 ? markup / 100 : markup;
 }
 
+/**
+ * Normalizes optional billing-account string values returned by upstream APIs.
+ *
+ * @param {unknown} rawValue String-like value from Projects API or Billing Accounts API.
+ * @returns {string|null} Trimmed string or `null` when the value is empty.
+ */
+function normalizeOptionalString(rawValue) {
+  if (_.isNil(rawValue)) {
+    return null;
+  }
+
+  const normalizedValue = _.toString(rawValue).trim();
+
+  return normalizedValue || null;
+}
+
+/**
+ * Normalizes optional billing-account boolean values returned by upstream APIs.
+ *
+ * @param {unknown} rawValue Boolean-like value from Projects API or Billing Accounts API.
+ * @returns {boolean|null} Parsed boolean or `null` when the value cannot be resolved.
+ */
+function normalizeOptionalBoolean(rawValue) {
+  if (_.isBoolean(rawValue)) {
+    return rawValue;
+  }
+
+  if (_.isString(rawValue)) {
+    const normalizedValue = rawValue.trim().toLowerCase();
+
+    if (normalizedValue === "true") {
+      return true;
+    }
+
+    if (normalizedValue === "false") {
+      return false;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Normalizes optional billing-account numeric values returned by upstream APIs.
+ *
+ * @param {unknown} rawValue Number-like value from Billing Accounts API.
+ * @returns {number|null} Parsed finite number or `null` when the value is empty.
+ */
+function normalizeOptionalNumber(rawValue) {
+  if (_.isNil(rawValue) || rawValue === "") {
+    return null;
+  }
+
+  const normalizedValue = _.toNumber(rawValue);
+
+  return Number.isFinite(normalizedValue) ? normalizedValue : null;
+}
+
 class ProjectHelper {
   /**
    * Get Project Details.
@@ -89,10 +147,13 @@ class ProjectHelper {
   }
 
   /**
-   * This functions gets the default billing account for a given project id
+   * Gets the default billing-account metadata for a project.
    *
-   * @param {Number} projectId The id of the project for which to get the default terms of use
-   * @returns {Promise<Number>} The billing account ID
+   * Returns the linked billing-account id and markup for challenge persistence,
+   * along with activity/expiry metadata used to validate challenge launches.
+   *
+   * @param {Number} projectId Project identifier whose default billing account should be fetched.
+   * @returns {Promise<object>} Normalized billing-account fields resolved from Projects API.
    */
   async getProjectBillingInformation(projectId) {
     const token = await m2mHelper.getM2MToken();
@@ -105,10 +166,14 @@ class ProjectHelper {
       logger.debug(
         `projectHelper.getProjectBillingInformation: response status ${res.status} for project ${projectId}`
       );
+      const active = normalizeOptionalBoolean(_.get(res, "data.active", null));
+      const endDate = normalizeOptionalString(_.get(res, "data.endDate", null));
 
       return {
         billingAccountId: _.get(res, "data.tcBillingAccountId", null),
         markup: normalizeBillingMarkup(_.get(res, "data.markup", null)),
+        ...(active !== null ? { active } : {}),
+        ...(endDate ? { endDate } : {}),
       };
     } catch (err) {
       const responseCode = _.get(err, "response.status");
@@ -126,6 +191,61 @@ class ProjectHelper {
         );
         throw err;
       }
+    }
+  }
+
+  /**
+   * Gets detailed billing-account metadata needed for launch validation.
+   *
+   * The Billing Accounts API is the source of truth for lifecycle status and
+   * remaining budget. Challenge launch validation uses this method to block
+   * launches for inactive, expired, or depleted billing accounts.
+   *
+   * @param {string|number} billingAccountId Billing-account identifier to fetch.
+   * @returns {Promise<object|null>} Normalized billing-account details, or `null` when not found.
+   */
+  async getBillingAccountDetails(billingAccountId) {
+    const normalizedBillingAccountId = normalizeOptionalString(billingAccountId);
+
+    if (!normalizedBillingAccountId) {
+      return null;
+    }
+
+    const token = await m2mHelper.getM2MToken();
+    const url = `${config.BILLING_ACCOUNTS_API_URL}/${encodeURIComponent(normalizedBillingAccountId)}`;
+    logger.debug(`projectHelper.getBillingAccountDetails: GET ${url}`);
+
+    try {
+      const res = await axios.get(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      logger.debug(
+        `projectHelper.getBillingAccountDetails: response status ${res.status} for billingAccountId ${normalizedBillingAccountId}`
+      );
+
+      return {
+        active: normalizeOptionalBoolean(_.get(res, "data.active", null)),
+        billingAccountId:
+          normalizeOptionalString(_.get(res, "data.id", null)) || normalizedBillingAccountId,
+        endDate: normalizeOptionalString(_.get(res, "data.endDate", null)),
+        status: normalizeOptionalString(_.get(res, "data.status", null)),
+        totalBudgetRemaining: normalizeOptionalNumber(
+          _.get(res, "data.totalBudgetRemaining", null)
+        ),
+      };
+    } catch (err) {
+      const responseCode = _.get(err, "response.status");
+
+      if (responseCode === HttpStatus.NOT_FOUND) {
+        return null;
+      }
+
+      logger.debug(
+        `projectHelper.getBillingAccountDetails: error for billingAccountId ${normalizedBillingAccountId} - status ${
+          responseCode || "n/a"
+        }: ${err.message}`
+      );
+      throw err;
     }
   }
 }

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -2408,6 +2408,168 @@ function validateTask(currentUser, challenge, data, challengeResources) {
   }
 }
 
+/**
+ * Normalizes optional text values used by launch validation.
+ *
+ * @param {unknown} value Raw upstream value.
+ * @returns {string|undefined} Trimmed string or `undefined` when empty.
+ */
+function normalizeOptionalString(value) {
+  if (_.isNil(value)) {
+    return undefined;
+  }
+
+  const normalizedValue = _.toString(value).trim();
+
+  return normalizedValue || undefined;
+}
+
+/**
+ * Normalizes optional numeric values used by launch validation.
+ *
+ * @param {unknown} value Raw upstream value.
+ * @returns {number|undefined} Parsed number or `undefined` when invalid.
+ */
+function normalizeOptionalNumber(value) {
+  if (_.isNil(value) || value === "") {
+    return undefined;
+  }
+
+  const normalizedValue = _.toNumber(value);
+
+  return Number.isFinite(normalizedValue) ? normalizedValue : undefined;
+}
+
+/**
+ * Resolves billing-account activity from either a boolean field or textual
+ * status returned by upstream services.
+ *
+ * @param {object|undefined|null} billingAccount Billing-account metadata.
+ * @returns {boolean|undefined} Billing-account activity flag when available.
+ */
+function resolveBillingAccountActive(billingAccount) {
+  if (_.isBoolean(_.get(billingAccount, "active"))) {
+    return billingAccount.active;
+  }
+
+  const normalizedStatus = normalizeOptionalString(_.get(billingAccount, "status"));
+
+  if (!normalizedStatus) {
+    return undefined;
+  }
+
+  if (normalizedStatus.toUpperCase() === "ACTIVE") {
+    return true;
+  }
+
+  if (normalizedStatus.toUpperCase() === "INACTIVE") {
+    return false;
+  }
+
+  return undefined;
+}
+
+/**
+ * Determines whether a billing account should be treated as expired.
+ *
+ * @param {boolean|undefined} active Billing-account activity flag.
+ * @param {string|undefined} endDate Billing-account end date.
+ * @returns {boolean} `true` when the billing account has expired.
+ */
+function isBillingAccountExpired(active, endDate) {
+  if (active === false) {
+    return true;
+  }
+
+  if (!endDate) {
+    return false;
+  }
+
+  const endDateTimestamp = Date.parse(endDate);
+
+  if (Number.isNaN(endDateTimestamp)) {
+    return false;
+  }
+
+  return Date.now() >= endDateTimestamp;
+}
+
+/**
+ * Validates the project billing account before activating a challenge.
+ *
+ * @param {object} params Validation inputs.
+ * @param {boolean|undefined|null} params.active Billing-account activity returned by Projects API.
+ * @param {string|number|null|undefined} params.billingAccountId Project billing-account identifier.
+ * @param {object} params.challenge Existing challenge model.
+ * @param {string|undefined|null} params.endDate Billing-account end date returned by Projects API.
+ * @returns {Promise<void>} Resolves when the billing account can be used for launch.
+ * @throws {errors.BadRequestError} When the billing account is missing, inactive, expired, or depleted.
+ */
+async function validateChallengeActivationBillingAccount({
+  active,
+  billingAccountId,
+  challenge,
+  endDate,
+}) {
+  if (!challengeHelper.isProjectIdRequired(challenge.timelineTemplateId)) {
+    return;
+  }
+
+  const normalizedBillingAccountId = normalizeOptionalString(billingAccountId);
+
+  if (!normalizedBillingAccountId) {
+    throw new errors.BadRequestError(
+      "Cannot activate challenge because the project has no billing account."
+    );
+  }
+
+  const resolvedProjectActive = _.isBoolean(active) ? active : undefined;
+  const resolvedProjectEndDate = normalizeOptionalString(endDate);
+
+  if (resolvedProjectActive === false) {
+    throw new errors.BadRequestError(
+      "Cannot activate challenge because the project billing account is inactive."
+    );
+  }
+
+  if (isBillingAccountExpired(resolvedProjectActive, resolvedProjectEndDate)) {
+    throw new errors.BadRequestError(
+      "Cannot activate challenge because the project billing account is expired."
+    );
+  }
+
+  const billingAccountDetails = await projectHelper.getBillingAccountDetails(normalizedBillingAccountId);
+  const resolvedActive = resolveBillingAccountActive(billingAccountDetails);
+  const resolvedEndDate =
+    normalizeOptionalString(_.get(billingAccountDetails, "endDate"));
+
+  if (!billingAccountDetails) {
+    throw new errors.BadRequestError(
+      "Cannot activate challenge because the project billing account could not be found."
+    );
+  }
+
+  if (resolvedActive === false) {
+    throw new errors.BadRequestError(
+      "Cannot activate challenge because the project billing account is inactive."
+    );
+  }
+
+  if (isBillingAccountExpired(resolvedActive, resolvedEndDate)) {
+    throw new errors.BadRequestError(
+      "Cannot activate challenge because the project billing account is expired."
+    );
+  }
+
+  const remainingBudget = normalizeOptionalNumber(billingAccountDetails.totalBudgetRemaining);
+
+  if (!_.isNil(remainingBudget) && remainingBudget <= 0) {
+    throw new errors.BadRequestError(
+      "Cannot activate challenge because the project billing account has insufficient remaining funds."
+    );
+  }
+}
+
 function prepareTaskCompletionData(challenge, challengeResources, data) {
   const isTask = helper.getTaskInfo(challenge).isTask || _.get(challenge, "legacy.pureV5Task");
   const isCompleteTask =
@@ -2500,14 +2662,19 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
 
   // No conversion needed - values are already in dollars in the database
 
-  let projectId, billingAccountId, markup;
+  let projectId, billingAccountId, markup, billingAccountActive, billingAccountEndDate;
   if (challengeHelper.isProjectIdRequired(challenge.timelineTemplateId)) {
     projectId = _.get(challenge, "projectId");
 
     logger.debug(
       `updateChallenge(${challengeId}): requesting billing information for project ${projectId}`,
     );
-    ({ billingAccountId, markup } = await projectHelper.getProjectBillingInformation(projectId));
+    ({
+      billingAccountId,
+      markup,
+      active: billingAccountActive,
+      endDate: billingAccountEndDate,
+    } = await projectHelper.getProjectBillingInformation(projectId));
     logger.debug(
       `updateChallenge(${challengeId}): billing lookup complete (hasAccount=${
         billingAccountId != null
@@ -2675,16 +2842,12 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
   let isChallengeBeingCancelled = false;
   if (data.status) {
     if (data.status === ChallengeStatusEnum.ACTIVE) {
-      // if activating a challenge, the challenge must have a billing account id
-      if (
-        (!billingAccountId || billingAccountId === null) &&
-        challenge.status === ChallengeStatusEnum.DRAFT &&
-        challengeHelper.isProjectIdRequired(challenge.timelineTemplateId)
-      ) {
-        throw new errors.BadRequestError(
-          "Cannot Activate this project, it has no active billing account.",
-        );
-      }
+      await validateChallengeActivationBillingAccount({
+        active: billingAccountActive,
+        billingAccountId,
+        challenge,
+        endDate: billingAccountEndDate,
+      });
     }
 
     if (
@@ -4425,6 +4588,9 @@ async function indexChallengeAndPostToKafka(updatedChallenge, track, type) {
 }
 
 module.exports = {
+  __testables: {
+    validateChallengeActivationBillingAccount,
+  },
   searchChallenges,
   createChallenge,
   getChallenge,

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -1072,6 +1072,35 @@ describe('challenge service unit tests', () => {
       })
     }
 
+    const createProjectActivationChallenge = async (status = ChallengeStatusEnum.NEW) => {
+      return prisma.challenge.create({
+        data: {
+          id: uuid(),
+          name: `Project activation check ${Date.now()}`,
+          description: 'project activation check',
+          typeId: data.challenge.typeId,
+          trackId: data.challenge.trackId,
+          timelineTemplateId: data.timelineTemplate.id,
+          projectId: 12345,
+          startDate: new Date(),
+          status,
+          tags: [],
+          groups: [],
+          createdBy: 'activation-test',
+          updatedBy: 'activation-test'
+        }
+      })
+    }
+
+    const buildActivationReviewers = () => ([
+      {
+        phaseId: data.phase.id,
+        scorecardId: 'activation-scorecard',
+        isMemberReview: false,
+        aiWorkflowId: 'workflow-123'
+      }
+    ])
+
     it('update challenge successfully 1', async () => {
       const challengeData = testChallengeData
       const result = await service.updateChallenge({ isMachine: true, sub: 'sub3', userId: 22838965 }, id, {
@@ -1606,14 +1635,7 @@ describe('challenge service unit tests', () => {
           activationChallenge.id,
           {
             status: ChallengeStatusEnum.ACTIVE,
-            reviewers: [
-              {
-                phaseId: data.phase.id,
-                scorecardId: 'activation-scorecard',
-                isMemberReview: false,
-                aiWorkflowId: 'workflow-123'
-              }
-            ]
+            reviewers: buildActivationReviewers()
           }
         )
         should.equal(updated.status, ChallengeStatusEnum.ACTIVE)
@@ -1621,6 +1643,147 @@ describe('challenge service unit tests', () => {
         should.equal(updated.reviewers.length, 1)
         should.equal(updated.reviewers[0].scorecardId, 'activation-scorecard')
       } finally {
+        await prisma.challenge.delete({ where: { id: activationChallenge.id } })
+      }
+    })
+
+    it('update challenge - prevent activating with an inactive project billing account', async () => {
+      const activationChallenge = await createProjectActivationChallenge(ChallengeStatusEnum.DRAFT)
+      const originalGetProjectBillingInformation = projectHelper.getProjectBillingInformation
+
+      projectHelper.getProjectBillingInformation = async () => ({
+        active: false,
+        billingAccountId: '80001061',
+        endDate: '2099-01-01T00:00:00.000Z',
+        markup: 0.25
+      })
+
+      try {
+        await service.updateChallenge(
+          { isMachine: true, sub: 'sub-activate', userId: 22838965 },
+          activationChallenge.id,
+          {
+            status: ChallengeStatusEnum.ACTIVE,
+            reviewers: buildActivationReviewers()
+          }
+        )
+      } catch (e) {
+        should.equal(e.message, 'Cannot activate challenge because the project billing account is inactive.')
+        return
+      } finally {
+        projectHelper.getProjectBillingInformation = originalGetProjectBillingInformation
+        await prisma.challenge.delete({ where: { id: activationChallenge.id } })
+      }
+
+      throw new Error('should not reach here')
+    })
+
+    it('update challenge - prevent activating with an expired project billing account', async () => {
+      const activationChallenge = await createProjectActivationChallenge(ChallengeStatusEnum.DRAFT)
+      const originalGetProjectBillingInformation = projectHelper.getProjectBillingInformation
+
+      projectHelper.getProjectBillingInformation = async () => ({
+        active: true,
+        billingAccountId: '80001061',
+        endDate: '2000-01-01T00:00:00.000Z',
+        markup: 0.25
+      })
+
+      try {
+        await service.updateChallenge(
+          { isMachine: true, sub: 'sub-activate', userId: 22838965 },
+          activationChallenge.id,
+          {
+            status: ChallengeStatusEnum.ACTIVE,
+            reviewers: buildActivationReviewers()
+          }
+        )
+      } catch (e) {
+        should.equal(e.message, 'Cannot activate challenge because the project billing account is expired.')
+        return
+      } finally {
+        projectHelper.getProjectBillingInformation = originalGetProjectBillingInformation
+        await prisma.challenge.delete({ where: { id: activationChallenge.id } })
+      }
+
+      throw new Error('should not reach here')
+    })
+
+    it('update challenge - prevent activating with insufficient project billing funds', async () => {
+      const activationChallenge = await createProjectActivationChallenge(ChallengeStatusEnum.DRAFT)
+      const originalGetProjectBillingInformation = projectHelper.getProjectBillingInformation
+      const originalGetBillingAccountDetails = projectHelper.getBillingAccountDetails
+
+      projectHelper.getProjectBillingInformation = async () => ({
+        active: true,
+        billingAccountId: '80001061',
+        endDate: '2099-01-01T00:00:00.000Z',
+        markup: 0.25
+      })
+      projectHelper.getBillingAccountDetails = async () => ({
+        active: true,
+        billingAccountId: '80001061',
+        endDate: '2099-01-01T00:00:00.000Z',
+        status: 'ACTIVE',
+        totalBudgetRemaining: 0
+      })
+
+      try {
+        await service.updateChallenge(
+          { isMachine: true, sub: 'sub-activate', userId: 22838965 },
+          activationChallenge.id,
+          {
+            status: ChallengeStatusEnum.ACTIVE,
+            reviewers: buildActivationReviewers()
+          }
+        )
+      } catch (e) {
+        should.equal(
+          e.message,
+          'Cannot activate challenge because the project billing account has insufficient remaining funds.'
+        )
+        return
+      } finally {
+        projectHelper.getProjectBillingInformation = originalGetProjectBillingInformation
+        projectHelper.getBillingAccountDetails = originalGetBillingAccountDetails
+        await prisma.challenge.delete({ where: { id: activationChallenge.id } })
+      }
+
+      throw new Error('should not reach here')
+    })
+
+    it('update challenge - allow activating with a valid project billing account', async () => {
+      const activationChallenge = await createProjectActivationChallenge(ChallengeStatusEnum.DRAFT)
+      const originalGetProjectBillingInformation = projectHelper.getProjectBillingInformation
+      const originalGetBillingAccountDetails = projectHelper.getBillingAccountDetails
+
+      projectHelper.getProjectBillingInformation = async () => ({
+        active: true,
+        billingAccountId: '80001061',
+        endDate: '2099-01-01T00:00:00.000Z',
+        markup: 0.25
+      })
+      projectHelper.getBillingAccountDetails = async () => ({
+        active: true,
+        billingAccountId: '80001061',
+        endDate: '2099-01-01T00:00:00.000Z',
+        status: 'ACTIVE',
+        totalBudgetRemaining: 150
+      })
+
+      try {
+        const updated = await service.updateChallenge(
+          { isMachine: true, sub: 'sub-activate', userId: 22838965 },
+          activationChallenge.id,
+          {
+            status: ChallengeStatusEnum.ACTIVE,
+            reviewers: buildActivationReviewers()
+          }
+        )
+        should.equal(updated.status, ChallengeStatusEnum.ACTIVE)
+      } finally {
+        projectHelper.getProjectBillingInformation = originalGetProjectBillingInformation
+        projectHelper.getBillingAccountDetails = originalGetBillingAccountDetails
         await prisma.challenge.delete({ where: { id: activationChallenge.id } })
       }
     })

--- a/test/unit/challenge-activation-billing.test.js
+++ b/test/unit/challenge-activation-billing.test.js
@@ -1,0 +1,120 @@
+if (!process.env.REVIEW_DB_URL && process.env.DATABASE_URL) {
+  process.env.REVIEW_DB_URL = process.env.DATABASE_URL;
+}
+
+require("../../app-bootstrap");
+const chai = require("chai");
+const service = require("../../src/services/ChallengeService");
+const projectHelper = require("../../src/common/project-helper");
+const { ChallengeStatusEnum } = require("../../src/common/prisma");
+
+const should = chai.should();
+
+describe("challenge activation billing validation unit tests", () => {
+  const validateChallengeActivationBillingAccount =
+    service.__testables.validateChallengeActivationBillingAccount;
+  const projectChallenge = {
+    status: ChallengeStatusEnum.DRAFT,
+    timelineTemplateId: "project-required-template",
+  };
+  const originalGetBillingAccountDetails = projectHelper.getBillingAccountDetails;
+
+  afterEach(() => {
+    projectHelper.getBillingAccountDetails = originalGetBillingAccountDetails;
+  });
+
+  it("prevents activation when the project has no billing account", async () => {
+    try {
+      await validateChallengeActivationBillingAccount({
+        billingAccountId: null,
+        challenge: projectChallenge,
+      });
+    } catch (error) {
+      should.equal(error.message, "Cannot activate challenge because the project has no billing account.");
+      return;
+    }
+
+    throw new Error("should not reach here");
+  });
+
+  it("prevents activation when the project billing account is inactive", async () => {
+    try {
+      await validateChallengeActivationBillingAccount({
+        active: false,
+        billingAccountId: "80001061",
+        challenge: projectChallenge,
+      });
+    } catch (error) {
+      should.equal(
+        error.message,
+        "Cannot activate challenge because the project billing account is inactive."
+      );
+      return;
+    }
+
+    throw new Error("should not reach here");
+  });
+
+  it("prevents activation when the project billing account is expired", async () => {
+    try {
+      await validateChallengeActivationBillingAccount({
+        active: true,
+        billingAccountId: "80001061",
+        challenge: projectChallenge,
+        endDate: "2000-01-01T00:00:00.000Z",
+      });
+    } catch (error) {
+      should.equal(
+        error.message,
+        "Cannot activate challenge because the project billing account is expired."
+      );
+      return;
+    }
+
+    throw new Error("should not reach here");
+  });
+
+  it("prevents activation when the project billing account has no remaining funds", async () => {
+    projectHelper.getBillingAccountDetails = async () => ({
+      active: true,
+      billingAccountId: "80001061",
+      endDate: "2099-01-01T00:00:00.000Z",
+      status: "ACTIVE",
+      totalBudgetRemaining: 0,
+    });
+
+    try {
+      await validateChallengeActivationBillingAccount({
+        active: true,
+        billingAccountId: "80001061",
+        challenge: projectChallenge,
+        endDate: "2099-01-01T00:00:00.000Z",
+      });
+    } catch (error) {
+      should.equal(
+        error.message,
+        "Cannot activate challenge because the project billing account has insufficient remaining funds."
+      );
+      return;
+    }
+
+    throw new Error("should not reach here");
+  });
+
+  it("allows activation when the billing account is active, unexpired, and funded", async () => {
+    projectHelper.getBillingAccountDetails = async () => ({
+      active: true,
+      billingAccountId: "80001061",
+      endDate: "2099-01-01T00:00:00.000Z",
+      status: "ACTIVE",
+      totalBudgetRemaining: 150,
+    });
+
+    await validateChallengeActivationBillingAccount({
+      active: true,
+      billingAccountId: "80001061",
+      challenge: projectChallenge,
+      endDate: "2099-01-01T00:00:00.000Z",
+    });
+  });
+});


### PR DESCRIPTION
What was broken
Challenges tied to projects could still be activated when the linked billing account was inactive, expired, or had no remaining budget.

Root cause
Activation validation only checked whether a project billing account id existed. It did not verify billing-account lifecycle state or remaining funds against the billing account data.

What was changed
Added billing-account detail lookup support in the project helper, including normalized active, end-date, status, and remaining-budget fields.
Updated challenge activation validation to block project-backed launches when the billing account is missing, inactive, expired, not found, or has no remaining funds.
Wired the billing account validation into challenge status updates while preserving the existing project billing-account persistence flow.

Any added/updated tests
Added focused unit coverage for the new activation billing-account validation paths.
Updated challenge service tests to cover inactive, expired, insufficient-funds, and valid billing-account activation scenarios.
Validation notes: `pnpm lint` passed. `pnpm build` could not run because this repo has no `build` script. `pnpm test` still fails in pre-existing `TimelineTemplateService` tests unrelated to this change, while the focused billing-account unit tests pass.
