### PR TITLE
PM-3167: tighten registration reopen dependency checks

### DIFF
--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -1,258 +1,261 @@
 /**
  * This service provides operations of challenge phases.
  */
-const _ = require("lodash");
-const Joi = require("joi");
-const moment = require("moment");
-const { Prisma } = require("@prisma/client");
-const config = require("config");
-const helper = require("../common/helper");
-const logger = require("../common/logger");
-const errors = require("../common/errors");
-const constants = require("../../app-constants");
-const { getReviewClient } = require("../common/review-prisma");
-const { indexChallengeAndPostToKafka, ensureAIScreeningCanBeClosed } = require("./ChallengeService");
+const _ = require('lodash')
+const Joi = require('joi')
+const moment = require('moment')
+const { Prisma } = require('@prisma/client')
+const config = require('config')
+const helper = require('../common/helper')
+const logger = require('../common/logger')
+const errors = require('../common/errors')
+const constants = require('../../app-constants')
+const { getReviewClient } = require('../common/review-prisma')
+const {
+  indexChallengeAndPostToKafka,
+  ensureAIScreeningCanBeClosed
+} = require('./ChallengeService')
 
-const { getClient } = require("../common/prisma");
-const prisma = getClient();
-const PENDING_REVIEW_STATUSES = Object.freeze(["PENDING", "IN_PROGRESS", "DRAFT", "SUBMITTED"]);
+const { getClient } = require('../common/prisma')
+const prisma = getClient()
+const PENDING_REVIEW_STATUSES = Object.freeze(['PENDING', 'IN_PROGRESS', 'DRAFT', 'SUBMITTED'])
 const REVIEW_PHASE_NAMES = Object.freeze([
-  "checkpoint review",
-  "checkpoint screening",
-  "screening",
-  "review",
-  "approval",
-]);
-const REVIEW_PHASE_NAME_SET = new Set(REVIEW_PHASE_NAMES.map((name) => name.toLowerCase()));
+  'checkpoint review',
+  'checkpoint screening',
+  'screening',
+  'review',
+  'approval'
+])
+const REVIEW_PHASE_NAME_SET = new Set(REVIEW_PHASE_NAMES.map((name) => name.toLowerCase()))
 const PHASE_RESOURCE_ROLE_REQUIREMENTS = Object.freeze({
-  "iterative review": "Iterative Reviewer",
-  "checkpoint screening": "Checkpoint Screener",
-  screening: "Screener",
-  review: "Reviewer",
-  approval: "Approver",
-  "checkpoint review": "Checkpoint Reviewer",
-});
-const SUBMISSION_PHASE_NAME_SET = new Set(["submission", "topgear submission"]);
-const REGISTRATION_PHASE_NAME = "registration";
+  'iterative review': 'Iterative Reviewer',
+  'checkpoint screening': 'Checkpoint Screener',
+  screening: 'Screener',
+  review: 'Reviewer',
+  approval: 'Approver',
+  'checkpoint review': 'Checkpoint Reviewer'
+})
+const normalizePhaseName = (name) =>
+  String(name || '')
+    .trim()
+    .toLowerCase()
 
-const normalizePhaseName = (name) => String(name || "").trim().toLowerCase();
-
-function datesAreSame(dateA, dateB) {
+function datesAreSame (dateA, dateB) {
   if (_.isNil(dateA) && _.isNil(dateB)) {
-    return true;
+    return true
   }
   if (_.isNil(dateA) || _.isNil(dateB)) {
-    return false;
+    return false
   }
-  return new Date(dateA).getTime() === new Date(dateB).getTime();
+  return new Date(dateA).getTime() === new Date(dateB).getTime()
 }
 
-function dateIsAfter(dateA, dateB) {
+function dateIsAfter (dateA, dateB) {
   if (_.isNil(dateA) || _.isNil(dateB)) {
-    return false;
+    return false
   }
-  const timeA = new Date(dateA).getTime();
-  const timeB = new Date(dateB).getTime();
+  const timeA = new Date(dateA).getTime()
+  const timeB = new Date(dateB).getTime()
   if (Number.isNaN(timeA) || Number.isNaN(timeB)) {
-    return false;
+    return false
   }
-  return timeA > timeB;
+  return timeA > timeB
 }
 
-function buildPhaseIdentifiers(phase) {
-  const identifiers = [];
+function buildPhaseIdentifiers (phase) {
+  const identifiers = []
   if (phase && phase.id) {
-    identifiers.push(String(phase.id));
+    identifiers.push(String(phase.id))
   }
   if (phase && !_.isNil(phase.phaseId)) {
-    identifiers.push(String(phase.phaseId));
+    identifiers.push(String(phase.phaseId))
   }
-  return identifiers;
+  return identifiers
 }
 
-async function recalculateDependentPhaseDates(tx, challengeId, predecessorPhase, currentUserId) {
+async function recalculateDependentPhaseDates (tx, challengeId, predecessorPhase, currentUserId) {
   if (!predecessorPhase || _.isNil(predecessorPhase.scheduledEndDate)) {
-    return;
+    return
   }
 
   const phases = await tx.challengePhase.findMany({
-    where: { challengeId },
-  });
+    where: { challengeId }
+  })
 
-  const successorsByPredecessor = new Map();
+  const successorsByPredecessor = new Map()
   for (const phase of phases) {
     if (_.isNil(phase.predecessor)) {
-      continue;
+      continue
     }
-    const key = String(phase.predecessor);
+    const key = String(phase.predecessor)
     if (!successorsByPredecessor.has(key)) {
-      successorsByPredecessor.set(key, []);
+      successorsByPredecessor.set(key, [])
     }
-    successorsByPredecessor.get(key).push(phase);
+    successorsByPredecessor.get(key).push(phase)
   }
 
-  const queue = [predecessorPhase];
-  const visited = new Set();
+  const queue = [predecessorPhase]
+  const visited = new Set()
 
   while (queue.length > 0) {
-    const currentPhase = queue.shift();
-    const currentEndDate = currentPhase?.scheduledEndDate;
+    const currentPhase = queue.shift()
+    const currentEndDate = currentPhase?.scheduledEndDate
     if (_.isNil(currentEndDate)) {
-      continue;
+      continue
     }
-    const predecessorKeys = buildPhaseIdentifiers(currentPhase);
+    const predecessorKeys = buildPhaseIdentifiers(currentPhase)
 
     for (const predecessorKey of predecessorKeys) {
-      const successors = successorsByPredecessor.get(predecessorKey) || [];
+      const successors = successorsByPredecessor.get(predecessorKey) || []
       for (const successor of successors) {
         if (visited.has(successor.id)) {
-          continue;
+          continue
         }
 
-        let successorForQueue = successor;
+        let successorForQueue = successor
         if (_.isNil(successor.actualStartDate)) {
-          const alignToPredecessorStart = normalizePhaseName(successor.name) === "iterative review";
+          const alignToPredecessorStart = normalizePhaseName(successor.name) === 'iterative review'
           const desiredStartDate = new Date(
             alignToPredecessorStart && currentPhase.scheduledStartDate
               ? currentPhase.scheduledStartDate
               : currentEndDate
-          );
-          const durationSeconds = Number(successor.duration);
+          )
+          const durationSeconds = Number(successor.duration)
           if (!Number.isFinite(durationSeconds) || Number.isNaN(desiredStartDate.getTime())) {
-            visited.add(successor.id);
-            queue.push(successorForQueue);
-            continue;
+            visited.add(successor.id)
+            queue.push(successorForQueue)
+            continue
           }
-          const desiredEndDate = new Date(desiredStartDate.getTime() + durationSeconds * 1000);
-          const startChanged = !datesAreSame(successor.scheduledStartDate, desiredStartDate);
-          const endChanged = !datesAreSame(successor.scheduledEndDate, desiredEndDate);
+          const desiredEndDate = new Date(desiredStartDate.getTime() + durationSeconds * 1000)
+          const startChanged = !datesAreSame(successor.scheduledStartDate, desiredStartDate)
+          const endChanged = !datesAreSame(successor.scheduledEndDate, desiredEndDate)
 
           if (startChanged || endChanged) {
             successorForQueue = await tx.challengePhase.update({
               data: {
                 scheduledStartDate: desiredStartDate,
                 scheduledEndDate: desiredEndDate,
-                updatedBy: currentUserId,
+                updatedBy: currentUserId
               },
               where: {
-                id: successor.id,
-              },
-            });
+                id: successor.id
+              }
+            })
           } else {
             successorForQueue = {
               ...successor,
               scheduledStartDate: successor.scheduledStartDate,
-              scheduledEndDate: successor.scheduledEndDate,
-            };
+              scheduledEndDate: successor.scheduledEndDate
+            }
           }
         }
 
-        visited.add(successor.id);
-        queue.push(successorForQueue);
+        visited.add(successor.id)
+        queue.push(successorForQueue)
       }
     }
   }
 }
 
-async function shiftDependentPhaseDates(tx, challengeId, predecessorPhase, deltaMs, currentUserId) {
+async function shiftDependentPhaseDates (tx, challengeId, predecessorPhase, deltaMs, currentUserId) {
   if (!predecessorPhase || !Number.isFinite(deltaMs) || deltaMs === 0) {
-    return;
+    return
   }
 
   const phases = await tx.challengePhase.findMany({
-    where: { challengeId },
-  });
+    where: { challengeId }
+  })
 
-  const successorsByPredecessor = new Map();
+  const successorsByPredecessor = new Map()
   for (const phase of phases) {
     if (_.isNil(phase.predecessor)) {
-      continue;
+      continue
     }
-    const key = String(phase.predecessor);
+    const key = String(phase.predecessor)
     if (!successorsByPredecessor.has(key)) {
-      successorsByPredecessor.set(key, []);
+      successorsByPredecessor.set(key, [])
     }
-    successorsByPredecessor.get(key).push(phase);
+    successorsByPredecessor.get(key).push(phase)
   }
 
-  const queue = [predecessorPhase];
-  const visited = new Set();
+  const queue = [predecessorPhase]
+  const visited = new Set()
 
   while (queue.length > 0) {
-    const currentPhase = queue.shift();
-    const predecessorKeys = buildPhaseIdentifiers(currentPhase);
+    const currentPhase = queue.shift()
+    const predecessorKeys = buildPhaseIdentifiers(currentPhase)
 
     for (const predecessorKey of predecessorKeys) {
-      const successors = successorsByPredecessor.get(predecessorKey) || [];
+      const successors = successorsByPredecessor.get(predecessorKey) || []
       for (const successor of successors) {
         if (visited.has(successor.id)) {
-          continue;
+          continue
         }
 
-        let successorForQueue = successor;
+        let successorForQueue = successor
         if (_.isNil(successor.actualStartDate)) {
           const scheduledStartTime = successor.scheduledStartDate
             ? new Date(successor.scheduledStartDate).getTime()
-            : Number.NaN;
+            : Number.NaN
           const scheduledEndTime = successor.scheduledEndDate
             ? new Date(successor.scheduledEndDate).getTime()
-            : Number.NaN;
+            : Number.NaN
 
           if (Number.isFinite(scheduledStartTime) && Number.isFinite(scheduledEndTime)) {
-            const desiredStartDate = new Date(scheduledStartTime + deltaMs);
-            const desiredEndDate = new Date(scheduledEndTime + deltaMs);
-            const startChanged = !datesAreSame(successor.scheduledStartDate, desiredStartDate);
-            const endChanged = !datesAreSame(successor.scheduledEndDate, desiredEndDate);
+            const desiredStartDate = new Date(scheduledStartTime + deltaMs)
+            const desiredEndDate = new Date(scheduledEndTime + deltaMs)
+            const startChanged = !datesAreSame(successor.scheduledStartDate, desiredStartDate)
+            const endChanged = !datesAreSame(successor.scheduledEndDate, desiredEndDate)
 
             if (startChanged || endChanged) {
               successorForQueue = await tx.challengePhase.update({
                 data: {
                   scheduledStartDate: desiredStartDate,
                   scheduledEndDate: desiredEndDate,
-                  updatedBy: currentUserId,
+                  updatedBy: currentUserId
                 },
                 where: {
-                  id: successor.id,
-                },
-              });
+                  id: successor.id
+                }
+              })
             } else {
               successorForQueue = {
                 ...successor,
                 scheduledStartDate: successor.scheduledStartDate,
-                scheduledEndDate: successor.scheduledEndDate,
-              };
+                scheduledEndDate: successor.scheduledEndDate
+              }
             }
           }
         }
 
-        visited.add(successor.id);
-        queue.push(successorForQueue);
+        visited.add(successor.id)
+        queue.push(successorForQueue)
       }
     }
   }
 }
 
-async function hasPendingScorecardsForPhase(challengePhaseId) {
+async function hasPendingScorecardsForPhase (challengePhaseId) {
   if (!config.REVIEW_DB_URL) {
     logger.debug(
       `Skipping pending scorecard check for phase ${challengePhaseId} because REVIEW_DB_URL is not configured`
-    );
-    return false;
+    )
+    return false
   }
 
-  const reviewPrisma = getReviewClient();
-  const reviewSchema = config.REVIEW_DB_SCHEMA;
-  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`);
-  const statusText = Prisma.raw(`"status"::text`);
+  const reviewPrisma = getReviewClient()
+  const reviewSchema = config.REVIEW_DB_SCHEMA
+  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`)
+  const statusText = Prisma.raw('"status"::text')
 
   const pendingStatusClause =
     PENDING_REVIEW_STATUSES.length > 0
       ? Prisma.sql`${statusText} IN (${Prisma.join(
           PENDING_REVIEW_STATUSES.map((status) => Prisma.sql`${status}`)
         )})`
-      : Prisma.sql`FALSE`;
+      : Prisma.sql`FALSE`
 
-  let rows;
+  let rows
   try {
     rows = await reviewPrisma.$queryRaw(
       Prisma.sql`
@@ -264,53 +267,53 @@ async function hasPendingScorecardsForPhase(challengePhaseId) {
             OR ${pendingStatusClause}
           )
       `
-    );
+    )
   } catch (err) {
     logger.error(
       `Failed to check pending scorecards for phase ${challengePhaseId}: ${err.message}`,
       err
-    );
-    throw err;
+    )
+    throw err
   }
 
-  const [{ count = 0 } = {}] = rows || [];
-  return Number(count) > 0;
+  const [{ count = 0 } = {}] = rows || []
+  return Number(count) > 0
 }
 
-async function hasCompletedReviewsForPhase(challengePhaseIdOrIds) {
+async function hasCompletedReviewsForPhase (challengePhaseIdOrIds) {
   if (!config.REVIEW_DB_URL) {
     logger.debug(
       `Skipping completed review check for phase ${challengePhaseIdOrIds} because REVIEW_DB_URL is not configured`
-    );
-    return false;
+    )
+    return false
   }
 
   const phaseIds = Array.isArray(challengePhaseIdOrIds)
     ? challengePhaseIdOrIds.filter((id) => !_.isNil(id))
-    : [challengePhaseIdOrIds];
+    : [challengePhaseIdOrIds]
 
   if (phaseIds.length === 0) {
-    return false;
+    return false
   }
 
-  const reviewPrisma = getReviewClient();
-  const reviewSchema = config.REVIEW_DB_SCHEMA;
-  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`);
-  const statusText = Prisma.raw(`"status"::text`);
-  const completedStatuses = ["IN_PROGRESS", "COMPLETED"];
+  const reviewPrisma = getReviewClient()
+  const reviewSchema = config.REVIEW_DB_SCHEMA
+  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`)
+  const statusText = Prisma.raw('"status"::text')
+  const completedStatuses = ['IN_PROGRESS', 'COMPLETED']
 
   const phaseIdClause =
     phaseIds.length === 1
       ? Prisma.sql`"phaseId" = ${phaseIds[0]}`
       : Prisma.sql`"phaseId" IN (${Prisma.join(
           phaseIds.map((phaseId) => Prisma.sql`${phaseId}`)
-        )})`;
+        )})`
 
   const completedStatusClause = Prisma.sql`${statusText} IN (${Prisma.join(
     completedStatuses.map((status) => Prisma.sql`${status}`)
-  )})`;
+  )})`
 
-  let rows;
+  let rows
   try {
     rows = await reviewPrisma.$queryRaw(
       Prisma.sql`
@@ -319,36 +322,36 @@ async function hasCompletedReviewsForPhase(challengePhaseIdOrIds) {
         WHERE ${phaseIdClause}
           AND ${completedStatusClause}
       `
-    );
+    )
   } catch (err) {
     logger.error(
-      `Failed to check completed reviews for phase(s) ${phaseIds.join(", ")}: ${err.message}`,
+      `Failed to check completed reviews for phase(s) ${phaseIds.join(', ')}: ${err.message}`,
       err
-    );
-    throw err;
+    )
+    throw err
   }
 
-  const [{ count = 0 } = {}] = rows || [];
-  return Number(count) > 0;
+  const [{ count = 0 } = {}] = rows || []
+  return Number(count) > 0
 }
 
-async function hasSubmittedAppealsForChallenge(challengeId) {
+async function hasSubmittedAppealsForChallenge (challengeId) {
   if (!config.REVIEW_DB_URL) {
     logger.debug(
       `Skipping submitted appeals check for challenge ${challengeId} because REVIEW_DB_URL is not configured`
-    );
-    return false;
+    )
+    return false
   }
 
-  const reviewPrisma = getReviewClient();
-  const reviewSchema = config.REVIEW_DB_SCHEMA;
-  const appealTable = Prisma.raw(`"${reviewSchema}"."appeal"`);
-  const reviewItemCommentTable = Prisma.raw(`"${reviewSchema}"."reviewItemComment"`);
-  const reviewItemTable = Prisma.raw(`"${reviewSchema}"."reviewItem"`);
-  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`);
-  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`);
+  const reviewPrisma = getReviewClient()
+  const reviewSchema = config.REVIEW_DB_SCHEMA
+  const appealTable = Prisma.raw(`"${reviewSchema}"."appeal"`)
+  const reviewItemCommentTable = Prisma.raw(`"${reviewSchema}"."reviewItemComment"`)
+  const reviewItemTable = Prisma.raw(`"${reviewSchema}"."reviewItem"`)
+  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`)
+  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`)
 
-  let rows;
+  let rows
   try {
     rows = await reviewPrisma.$queryRaw(
       Prisma.sql`
@@ -367,37 +370,37 @@ async function hasSubmittedAppealsForChallenge(challengeId) {
             )
         )
       `
-    );
+    )
   } catch (err) {
     logger.error(
       `Failed to check submitted appeals for challenge ${challengeId}: ${err.message}`,
       err
-    );
-    throw err;
+    )
+    throw err
   }
 
-  const [{ count = 0 } = {}] = rows || [];
-  return Number(count) > 0;
+  const [{ count = 0 } = {}] = rows || []
+  return Number(count) > 0
 }
 
-async function hasPendingAppealResponsesForChallenge(challengeId) {
+async function hasPendingAppealResponsesForChallenge (challengeId) {
   if (!config.REVIEW_DB_URL) {
     logger.debug(
       `Skipping pending appeal response check for challenge ${challengeId} because REVIEW_DB_URL is not configured`
-    );
-    return false;
+    )
+    return false
   }
 
-  const reviewPrisma = getReviewClient();
-  const reviewSchema = config.REVIEW_DB_SCHEMA;
-  const appealTable = Prisma.raw(`"${reviewSchema}"."appeal"`);
-  const appealResponseTable = Prisma.raw(`"${reviewSchema}"."appealResponse"`);
-  const reviewItemCommentTable = Prisma.raw(`"${reviewSchema}"."reviewItemComment"`);
-  const reviewItemTable = Prisma.raw(`"${reviewSchema}"."reviewItem"`);
-  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`);
-  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`);
+  const reviewPrisma = getReviewClient()
+  const reviewSchema = config.REVIEW_DB_SCHEMA
+  const appealTable = Prisma.raw(`"${reviewSchema}"."appeal"`)
+  const appealResponseTable = Prisma.raw(`"${reviewSchema}"."appealResponse"`)
+  const reviewItemCommentTable = Prisma.raw(`"${reviewSchema}"."reviewItemComment"`)
+  const reviewItemTable = Prisma.raw(`"${reviewSchema}"."reviewItem"`)
+  const reviewTable = Prisma.raw(`"${reviewSchema}"."review"`)
+  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`)
 
-  let rows;
+  let rows
   try {
     rows = await reviewPrisma.$queryRaw(
       Prisma.sql`
@@ -418,34 +421,34 @@ async function hasPendingAppealResponsesForChallenge(challengeId) {
               )
           )
       `
-    );
+    )
   } catch (err) {
     logger.error(
       `Failed to check pending appeal responses for challenge ${challengeId}: ${err.message}`,
       err
-    );
-    throw err;
+    )
+    throw err
   }
 
-  const [{ count = 0 } = {}] = rows || [];
-  return Number(count) > 0;
+  const [{ count = 0 } = {}] = rows || []
+  return Number(count) > 0
 }
 
-async function hasPendingEscalationRequestsForChallenge(challengeId) {
+async function hasPendingEscalationRequestsForChallenge (challengeId) {
   if (!config.REVIEW_DB_URL) {
     logger.debug(
       `Skipping pending escalation request check for challenge ${challengeId} because REVIEW_DB_URL is not configured`
-    );
-    return false;
+    )
+    return false
   }
 
-  const reviewPrisma = getReviewClient();
-  const reviewSchema = config.REVIEW_DB_SCHEMA;
-  const escalationTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecisionEscalation"`);
-  const decisionTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecision"`);
-  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`);
+  const reviewPrisma = getReviewClient()
+  const reviewSchema = config.REVIEW_DB_SCHEMA
+  const escalationTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecisionEscalation"`)
+  const decisionTable = Prisma.raw(`"${reviewSchema}"."aiReviewDecision"`)
+  const submissionTable = Prisma.raw(`"${reviewSchema}"."submission"`)
 
-  let rows;
+  let rows
   try {
     rows = await reviewPrisma.$queryRaw(
       Prisma.sql`
@@ -460,23 +463,23 @@ async function hasPendingEscalationRequestsForChallenge(challengeId) {
               AND s."id" = ard."submissionId"
           )
       `
-    );
+    )
   } catch (err) {
     logger.error(
       `Failed to check pending escalation requests for challenge ${challengeId}: ${err.message}`,
       err
-    );
-    throw err;
+    )
+    throw err
   }
 
-  const [{ count = 0 } = {}] = rows || [];
-  return Number(count) > 0;
+  const [{ count = 0 } = {}] = rows || []
+  return Number(count) > 0
 }
 
-async function checkChallengeExists(challengeId) {
-  const challenge = await prisma.challenge.findUnique({ where: { id: challengeId } });
+async function checkChallengeExists (challengeId) {
+  const challenge = await prisma.challenge.findUnique({ where: { id: challengeId } })
   if (!challenge) {
-    throw new errors.NotFoundError(`Challenge with id: ${challengeId} doesn't exist`);
+    throw new errors.NotFoundError(`Challenge with id: ${challengeId} doesn't exist`)
   }
 }
 
@@ -484,62 +487,62 @@ async function checkChallengeExists(challengeId) {
  * Publish a challenge update event with the latest challenge payload.
  * @param {String} challengeId the challenge id
  */
-async function postChallengeUpdatedNotification(challengeId) {
+async function postChallengeUpdatedNotification (challengeId) {
   try {
-    const challenge = await prisma.challenge.findUnique({ where: { id: challengeId } });
+    const challenge = await prisma.challenge.findUnique({ where: { id: challengeId } })
     if (!challenge) {
-      logger.error(`Failed to publish challenge update event: challenge ${challengeId} not found`);
-      return;
+      logger.error(`Failed to publish challenge update event: challenge ${challengeId} not found`)
+      return
     }
-    await indexChallengeAndPostToKafka(challenge);
+    await indexChallengeAndPostToKafka(challenge)
   } catch (error) {
     logger.error(
       `Failed to publish challenge update event for challenge ${challengeId}: ${error.message}`,
       error
-    );
-    throw error;
+    )
+    throw error
   }
 }
 
-async function ensureRequiredResourcesBeforeOpeningPhase(challengeId, phaseName) {
-  const normalizedPhaseName = _.toLower(_.trim(phaseName || ""));
-  const requiredRoleName = PHASE_RESOURCE_ROLE_REQUIREMENTS[normalizedPhaseName];
+async function ensureRequiredResourcesBeforeOpeningPhase (challengeId, phaseName) {
+  const normalizedPhaseName = _.toLower(_.trim(phaseName || ''))
+  const requiredRoleName = PHASE_RESOURCE_ROLE_REQUIREMENTS[normalizedPhaseName]
   if (!requiredRoleName) {
-    return;
+    return
   }
 
-  const challengeResources = await helper.getChallengeResources(challengeId);
-  const requiredRoleNameLower = _.toLower(requiredRoleName);
+  const challengeResources = await helper.getChallengeResources(challengeId)
+  const requiredRoleNameLower = _.toLower(requiredRoleName)
   const hasRequiredRoleByName = (challengeResources || []).some((resource) => {
     const roleName =
       resource.roleName ||
       resource.role ||
-      _.get(resource, "role.name") ||
-      _.get(resource, "resourceRoleName") ||
-      _.get(resource, "resourceRole.name");
-    return roleName && _.toLower(roleName) === requiredRoleNameLower;
-  });
+      _.get(resource, 'role.name') ||
+      _.get(resource, 'resourceRoleName') ||
+      _.get(resource, 'resourceRole.name')
+    return roleName && _.toLower(roleName) === requiredRoleNameLower
+  })
 
-  let hasRequiredRole = hasRequiredRoleByName;
+  let hasRequiredRole = hasRequiredRoleByName
 
   if (!hasRequiredRole) {
-    const resourceRoles = await helper.getResourceRoles();
+    const resourceRoles = await helper.getResourceRoles()
     const requiredRoleIds = (resourceRoles || [])
       .filter((role) => role.name && _.toLower(role.name) === requiredRoleNameLower)
-      .map((role) => _.toString(role.id));
+      .map((role) => _.toString(role.id))
     if (requiredRoleIds.length > 0) {
-      const requiredRoleIdSet = new Set(requiredRoleIds);
+      const requiredRoleIdSet = new Set(requiredRoleIds)
       hasRequiredRole = (challengeResources || []).some(
         (resource) => resource.roleId && requiredRoleIdSet.has(_.toString(resource.roleId))
-      );
+      )
     }
   }
 
   if (!hasRequiredRole) {
-    const displayPhaseName = phaseName || "phase";
+    const displayPhaseName = phaseName || 'phase'
     throw new errors.BadRequestError(
       `Cannot open ${displayPhaseName} phase because the challenge does not have any resource with the ${requiredRoleName} role`
-    );
+    )
   }
 }
 
@@ -548,26 +551,26 @@ async function ensureRequiredResourcesBeforeOpeningPhase(challengeId, phaseName)
  * @param {String} challengeId the challenge id
  * @returns {[Object]} the list of challenge phase
  */
-async function getAllChallengePhases(challengeId) {
-  await checkChallengeExists(challengeId);
+async function getAllChallengePhases (challengeId) {
+  await checkChallengeExists(challengeId)
   const result = await prisma.challengePhase.findMany({
     where: { challengeId },
-    include: { phase: true, constraints: true },
-  });
+    include: { phase: true, constraints: true }
+  })
 
   return _.map(result, (obj) => {
-    const ret = _.omit(obj, constants.auditFields);
-    ret.phase = _.omit(obj.phase, constants.auditFields);
+    const ret = _.omit(obj, constants.auditFields)
+    ret.phase = _.omit(obj.phase, constants.auditFields)
     ret.constraints = _.map(obj.constraints, (constraint) =>
       _.omit(constraint, constants.auditFields)
-    );
-    return ret;
-  });
+    )
+    return ret
+  })
 }
 
 getAllChallengePhases.schema = {
-  challengeId: Joi.id(),
-};
+  challengeId: Joi.id()
+}
 
 /**
  * Get challenge phase.
@@ -575,27 +578,27 @@ getAllChallengePhases.schema = {
  * @param {String} id the challenge phase id
  * @returns {Object} the challengePhase with given challengeId and id
  */
-async function getChallengePhase(challengeId, id) {
-  await checkChallengeExists(challengeId);
+async function getChallengePhase (challengeId, id) {
+  await checkChallengeExists(challengeId)
   const result = await prisma.challengePhase.findFirst({
     where: { challengeId, id },
-    include: { phase: true, constraints: true },
-  });
+    include: { phase: true, constraints: true }
+  })
   if (!result) {
     throw new errors.NotFoundError(
       `ChallengePhase with challengeId: ${challengeId},  phaseId: ${id} doesn't exist`
-    );
+    )
   }
-  const ret = _.omit(result, constants.auditFields);
-  ret.phase = _.omit(result.phase, constants.auditFields);
-  ret.constraints = _.map(result.constraints, (constraint) => _.omit(constraint));
-  return ret;
+  const ret = _.omit(result, constants.auditFields)
+  ret.phase = _.omit(result.phase, constants.auditFields)
+  ret.constraints = _.map(result.constraints, (constraint) => _.omit(constraint))
+  return ret
 }
 
 getChallengePhase.schema = {
   challengeId: Joi.id(),
-  id: Joi.id(),
-};
+  id: Joi.id()
+}
 
 /**
  * Partially update challenge phase
@@ -604,65 +607,59 @@ getChallengePhase.schema = {
  * @param {String} id the phase id
  * @returns {Object} the updated challengePhase
  */
-async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data) {
-  await checkChallengeExists(challengeId);
+async function partiallyUpdateChallengePhase (currentUser, challengeId, id, data) {
+  await checkChallengeExists(challengeId)
   const challengePhase = await prisma.challengePhase.findFirst({
     where: { challengeId, id },
-    include: { constraints: true },
-  });
+    include: { constraints: true }
+  })
   if (!challengePhase) {
     throw new errors.NotFoundError(
       `ChallengePhase with challengeId: ${challengeId},  phaseId: ${id} doesn't exist`
-    );
+    )
   }
-  const originalScheduledEndDate = challengePhase.scheduledEndDate;
+  const originalScheduledEndDate = challengePhase.scheduledEndDate
   const shouldAttemptSuccessorRecalc = Boolean(
     data.duration || data.scheduledStartDate || data.scheduledEndDate
-  );
+  )
   // isOpen should be false if it's passed as null
-  if ("isOpen" in data) {
-    if (!data["isOpen"]) {
-      data["isOpen"] = false;
+  if ('isOpen' in data) {
+    if (!data.isOpen) {
+      data.isOpen = false
     }
   }
 
   // check ChallengePhase data
-  if (data["phaseId"]) {
-    const phase = await prisma.phase.findUnique({ where: { id: data["phaseId"] } });
+  if (data.phaseId) {
+    const phase = await prisma.phase.findUnique({ where: { id: data.phaseId } })
     if (!phase) {
-      throw new errors.BadRequestError(`phaseId should be a valid phase`);
+      throw new errors.BadRequestError('phaseId should be a valid phase')
     }
   }
 
-  if (data["predecessor"]) {
+  if (data.predecessor) {
     const predecessor = await prisma.challengePhase.findFirst({
       where: {
         challengeId,
-        OR: [
-          { id: data["predecessor"] },
-          { phaseId: data["predecessor"] },
-        ],
-      },
-    });
+        OR: [{ id: data.predecessor }, { phaseId: data.predecessor }]
+      }
+    })
     if (!predecessor) {
       throw new errors.BadRequestError(
         `predecessor should be a valid challenge phase in the same challenge: ${challengeId}`
-      );
+      )
     }
   }
 
-  const isOpeningPhase = "isOpen" in data && data["isOpen"] === true;
-  const predecessorId = data["predecessor"] || challengePhase.predecessor;
+  const isOpeningPhase = 'isOpen' in data && data.isOpen === true
+  const predecessorId = data.predecessor || challengePhase.predecessor
   if (isOpeningPhase && predecessorId) {
     const predecessorPhase = await prisma.challengePhase.findFirst({
       where: {
         challengeId,
-        OR: [
-          { id: predecessorId },
-          { phaseId: predecessorId },
-        ],
-      },
-    });
+        OR: [{ id: predecessorId }, { phaseId: predecessorId }]
+      }
+    })
 
     if (
       !predecessorPhase ||
@@ -671,250 +668,241 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       _.isNil(predecessorPhase.actualEndDate)
     ) {
       throw new errors.BadRequestError(
-        "Cannot open phase because predecessor phase must be closed with both actualStartDate and actualEndDate set"
-      );
+        'Cannot open phase because predecessor phase must be closed with both actualStartDate and actualEndDate set'
+      )
     }
   }
 
   if (isOpeningPhase) {
-    const phaseName = data.name || challengePhase.name;
-    await ensureRequiredResourcesBeforeOpeningPhase(challengeId, phaseName);
+    const phaseName = data.name || challengePhase.name
+    await ensureRequiredResourcesBeforeOpeningPhase(challengeId, phaseName)
 
     // Check if this is the Appeals phase
-    const normalizedPhaseName = normalizePhaseName(phaseName);
-    if (normalizedPhaseName === "appeals") {
-      const hasPendingEscalations = await hasPendingEscalationRequestsForChallenge(challengeId);
+    const normalizedPhaseName = normalizePhaseName(phaseName)
+    if (normalizedPhaseName === 'appeals') {
+      const hasPendingEscalations = await hasPendingEscalationRequestsForChallenge(challengeId)
       if (hasPendingEscalations) {
         throw new errors.BadRequestError(
-          "Cannot open Appeals phase because there are pending escalation requests that need to be resolved first"
-        );
+          'Cannot open Appeals phase because there are pending escalation requests that need to be resolved first'
+        )
       }
     }
   }
 
-  if (data["scheduledStartDate"] || data["scheduledEndDate"]) {
-    const startDate = data["scheduledStartDate"] || challengePhase.scheduledStartDate;
-    const endDate = data["scheduledEndDate"] || challengePhase.scheduledEndDate;
+  if (data.scheduledStartDate || data.scheduledEndDate) {
+    const startDate = data.scheduledStartDate || challengePhase.scheduledStartDate
+    const endDate = data.scheduledEndDate || challengePhase.scheduledEndDate
     if (moment(startDate).isAfter(moment(endDate))) {
       throw new errors.BadRequestError(
         `scheduledStartDate: ${startDate.toISOString()} should not be after scheduledEndDate: ${endDate.toISOString()}`
-      );
+      )
     }
   }
 
-  if (data["actualStartDate"] || data["actualEndDate"]) {
-    const startDate = data["actualStartDate"] || challengePhase.actualStartDate;
-    const endDate = data["actualEndDate"] || challengePhase.actualEndDate;
+  if (data.actualStartDate || data.actualEndDate) {
+    const startDate = data.actualStartDate || challengePhase.actualStartDate
+    const endDate = data.actualEndDate || challengePhase.actualEndDate
     if (moment(startDate).isAfter(moment(endDate))) {
       throw new errors.BadRequestError(
         `actualStartDate: ${startDate.toISOString()} should not be after actualEndDate: ${endDate.toISOString()}`
-      );
+      )
     }
   }
 
-  if (data["constraints"] && data["constraints"].length > 0) {
-    for (const constrain of data["constraints"]) {
+  if (data.constraints && data.constraints.length > 0) {
+    for (const constrain of data.constraints) {
       if (constrain.id && !challengePhase.constraints.some((cst) => cst.id === constrain.id)) {
         throw new errors.BadRequestError(
           `constraint: ${constrain.id} is not exists for the ChallengePhase`
-        );
+        )
       }
     }
   }
 
   const isClosingPhase =
-    "isOpen" in data && data["isOpen"] === false && Boolean(challengePhase.isOpen);
-  const isReopeningPhase =
-    "isOpen" in data && data["isOpen"] === true && !challengePhase.isOpen;
+    'isOpen' in data && data.isOpen === false && Boolean(challengePhase.isOpen)
+  const isReopeningPhase = 'isOpen' in data && data.isOpen === true && !challengePhase.isOpen
   if (isClosingPhase) {
-    const closingPhaseName = data.name || challengePhase.name;
-    const normalizedClosingPhaseName = normalizePhaseName(closingPhaseName);
-    const pendingScorecards = await hasPendingScorecardsForPhase(challengePhase.id);
+    const closingPhaseName = data.name || challengePhase.name
+    const normalizedClosingPhaseName = normalizePhaseName(closingPhaseName)
+    const pendingScorecards = await hasPendingScorecardsForPhase(challengePhase.id)
     if (pendingScorecards) {
-      const phaseName = closingPhaseName || "phase";
+      const phaseName = closingPhaseName || 'phase'
       throw new errors.ForbiddenError(
         `Cannot close ${phaseName} because there are still pending scorecards`
-      );
+      )
     }
     if (
-      normalizedClosingPhaseName === "review" &&
+      normalizedClosingPhaseName === 'review' &&
       (await hasPendingEscalationRequestsForChallenge(challengePhase.challengeId))
     ) {
       throw new errors.BadRequestError(
-        "Cannot close Review phase because there are pending escalation requests that need to be resolved first"
-      );
+        'Cannot close Review phase because there are pending escalation requests that need to be resolved first'
+      )
     }
     if (
-      normalizedClosingPhaseName === "appeals response" &&
+      normalizedClosingPhaseName === 'appeals response' &&
       (await hasPendingAppealResponsesForChallenge(challengePhase.challengeId))
     ) {
       throw new errors.BadRequestError(
         "Appeals Response phase can't be closed because there are still appeals that haven't been responded to"
-      );
+      )
     }
 
-    if (normalizedClosingPhaseName === "ai screening") {
-      await ensureAIScreeningCanBeClosed(challengePhase.challengeId);
+    if (normalizedClosingPhaseName === 'ai screening') {
+      await ensureAIScreeningCanBeClosed(challengePhase.challengeId)
     }
 
-    if (!("actualEndDate" in data) || _.isNil(data.actualEndDate)) {
-      data.actualEndDate = new Date();
+    if (!('actualEndDate' in data) || _.isNil(data.actualEndDate)) {
+      data.actualEndDate = new Date()
     }
   }
   if (isReopeningPhase) {
-    const phaseName = challengePhase.name;
+    const phaseName = challengePhase.name
     const openPhases = await prisma.challengePhase.findMany({
       where: {
         challengeId: challengePhase.challengeId,
-        isOpen: true,
+        isOpen: true
       },
       select: {
         id: true,
         phaseId: true,
         predecessor: true,
-        name: true,
-      },
-    });
+        name: true
+      }
+    })
     const activeReviewPhase = openPhases.find((phase) =>
-      REVIEW_PHASE_NAME_SET.has(String(phase?.name || "").toLowerCase())
-    );
+      REVIEW_PHASE_NAME_SET.has(String(phase?.name || '').toLowerCase())
+    )
     if (activeReviewPhase) {
-      const hasActiveScorecards = await hasCompletedReviewsForPhase(
-        activeReviewPhase.id
-      );
+      const hasActiveScorecards = await hasCompletedReviewsForPhase(activeReviewPhase.id)
       if (hasActiveScorecards) {
         throw new errors.BadRequestError(
           `Cannot reopen ${phaseName} because the currently open phase '${activeReviewPhase.name}' has reviews in progress or completed`
-        );
+        )
       }
     }
-    if (phaseName === "Submission" || phaseName === "Registration") {
-      const hasCompletedReviews = await hasCompletedReviewsForPhase(challengePhase.id);
+    if (phaseName === 'Submission' || phaseName === 'Registration') {
+      const hasCompletedReviews = await hasCompletedReviewsForPhase(challengePhase.id)
       if (hasCompletedReviews) {
         throw new errors.ForbiddenError(
-          "Cannot reopen Submission/Registration phase because reviews are already in progress or completed"
-        );
+          'Cannot reopen Submission/Registration phase because reviews are already in progress or completed'
+        )
       }
     }
 
-    if (phaseName === "Checkpoint Submission") {
+    if (phaseName === 'Checkpoint Submission') {
       const checkpointPhases = await prisma.challengePhase.findMany({
         where: {
           challengeId: challengePhase.challengeId,
-          name: { in: ["Checkpoint Screening", "Checkpoint Review"] },
+          name: { in: ['Checkpoint Screening', 'Checkpoint Review'] }
         },
-        select: { id: true },
-      });
-      const checkpointPhaseIds = checkpointPhases.map((cp) => cp.id);
+        select: { id: true }
+      })
+      const checkpointPhaseIds = checkpointPhases.map((cp) => cp.id)
       if (checkpointPhaseIds.length > 0) {
-        const hasCheckpointReviews = await hasCompletedReviewsForPhase(checkpointPhaseIds);
+        const hasCheckpointReviews = await hasCompletedReviewsForPhase(checkpointPhaseIds)
         if (hasCheckpointReviews) {
           throw new errors.ForbiddenError(
-            "Cannot reopen Checkpoint Submission phase because Checkpoint Screening or Checkpoint Review reviews are already in progress or completed"
-          );
+            'Cannot reopen Checkpoint Submission phase because Checkpoint Screening or Checkpoint Review reviews are already in progress or completed'
+          )
         }
       }
     }
 
-    const hasActualStartDate = !_.isNil(challengePhase.actualStartDate);
-    const hasActualEndDate = !_.isNil(challengePhase.actualEndDate);
+    const hasActualStartDate = !_.isNil(challengePhase.actualStartDate)
+    const hasActualEndDate = !_.isNil(challengePhase.actualEndDate)
 
     if (hasActualStartDate && hasActualEndDate && openPhases.length > 0) {
-      const reopenedPhaseIdentifiers = new Set([String(challengePhase.id)]);
+      const reopenedPhaseIdentifiers = new Set([String(challengePhase.id)])
       if (!_.isNil(challengePhase.phaseId)) {
-        reopenedPhaseIdentifiers.add(String(challengePhase.phaseId));
+        reopenedPhaseIdentifiers.add(String(challengePhase.phaseId))
       }
 
       const dependentOpenPhases = openPhases.filter((phase) => {
         if (!phase || _.isNil(phase.predecessor)) {
-          return false;
+          return false
         }
-        return reopenedPhaseIdentifiers.has(String(phase.predecessor));
-      });
+        return reopenedPhaseIdentifiers.has(String(phase.predecessor))
+      })
 
-      const normalizedPhaseName = normalizePhaseName(phaseName);
-      const hasSubmissionVariantOpen = openPhases.some((phase) =>
-        SUBMISSION_PHASE_NAME_SET.has(normalizePhaseName(phase?.name))
-      );
-      const allowRegistrationReopenWithoutExplicitDependency =
-        normalizedPhaseName === REGISTRATION_PHASE_NAME && hasSubmissionVariantOpen;
-
-      if (dependentOpenPhases.length === 0 && !allowRegistrationReopenWithoutExplicitDependency) {
+      if (dependentOpenPhases.length === 0) {
         throw new errors.ForbiddenError(
           `Cannot reopen ${phaseName} because no currently open phase depends on it`
-        );
+        )
       }
 
       const appealsDependentPhaseExists = dependentOpenPhases.some(
-        (phase) => String(phase.name || "").toLowerCase() === "appeals"
-      );
+        (phase) => String(phase.name || '').toLowerCase() === 'appeals'
+      )
       if (appealsDependentPhaseExists) {
         const hasSubmittedAppeals = await hasSubmittedAppealsForChallenge(
           challengePhase.challengeId
-        );
+        )
         if (hasSubmittedAppeals) {
           throw new errors.ForbiddenError(
             `Cannot reopen ${phaseName} because submitted appeals already exist in the Appeals phase`
-          );
+          )
         }
       }
     }
 
     if (hasActualStartDate) {
-      data.actualStartDate = challengePhase.actualStartDate;
-    } else if (!("actualStartDate" in data) || _.isNil(data.actualStartDate)) {
-      data.actualStartDate = new Date();
+      data.actualStartDate = challengePhase.actualStartDate
+    } else if (!('actualStartDate' in data) || _.isNil(data.actualStartDate)) {
+      data.actualStartDate = new Date()
     }
-    data.actualEndDate = null;
+    data.actualEndDate = null
   }
 
   // Update ChallengePhase
-  const currentUserId = String(currentUser.userId);
-  data.updatedBy = currentUserId;
+  const currentUserId = String(currentUser.userId)
+  data.updatedBy = currentUserId
   if (!_.isNil(data.duration)) {
     const startInput = !_.isNil(data.scheduledStartDate)
       ? data.scheduledStartDate
       : !_.isNil(challengePhase.scheduledStartDate)
-      ? challengePhase.scheduledStartDate
-      : null;
+          ? challengePhase.scheduledStartDate
+          : null
     if (startInput) {
-      const startDate = new Date(startInput);
+      const startDate = new Date(startInput)
       if (!Number.isNaN(startDate.getTime())) {
         const recalculatedScheduledEndDate = new Date(
           startDate.getTime() + Number(data.duration) * 1000
-        );
-        data.scheduledEndDate = recalculatedScheduledEndDate;
+        )
+        data.scheduledEndDate = recalculatedScheduledEndDate
       }
     }
   }
-  const dataToUpdate = _.omit(data, "constraints");
+  const dataToUpdate = _.omit(data, 'constraints')
   const shouldRefreshPhaseNames =
-    Object.prototype.hasOwnProperty.call(data, "isOpen") ||
-    Object.prototype.hasOwnProperty.call(data, "name");
+    Object.prototype.hasOwnProperty.call(data, 'isOpen') ||
+    Object.prototype.hasOwnProperty.call(data, 'name')
   const result = await prisma.$transaction(async (tx) => {
     const updatedPhase = await tx.challengePhase.update({
       data: dataToUpdate,
       where: {
-        id: challengePhase.id,
-      },
-    });
-    let scheduleExtended = false;
+        id: challengePhase.id
+      }
+    })
+    let scheduleExtended = false
     if (shouldAttemptSuccessorRecalc) {
-      scheduleExtended = dateIsAfter(
-        updatedPhase.scheduledEndDate,
-        originalScheduledEndDate
-      );
+      scheduleExtended = dateIsAfter(updatedPhase.scheduledEndDate, originalScheduledEndDate)
       if (scheduleExtended) {
-        await recalculateDependentPhaseDates(tx, challengeId, updatedPhase, currentUserId);
+        await recalculateDependentPhaseDates(tx, challengeId, updatedPhase, currentUserId)
       }
     }
-    if (isClosingPhase && !_.isNil(originalScheduledEndDate) && !_.isNil(updatedPhase.actualEndDate)) {
+    if (
+      isClosingPhase &&
+      !_.isNil(originalScheduledEndDate) &&
+      !_.isNil(updatedPhase.actualEndDate)
+    ) {
       const shiftBaselineScheduledEndDate =
         scheduleExtended && !_.isNil(updatedPhase.scheduledEndDate)
           ? updatedPhase.scheduledEndDate
-          : originalScheduledEndDate;
-      const scheduledEndTime = new Date(shiftBaselineScheduledEndDate).getTime();
-      const actualEndTime = new Date(updatedPhase.actualEndDate).getTime();
+          : originalScheduledEndDate
+      const scheduledEndTime = new Date(shiftBaselineScheduledEndDate).getTime()
+      const actualEndTime = new Date(updatedPhase.actualEndDate).getTime()
 
       if (Number.isFinite(scheduledEndTime) && Number.isFinite(actualEndTime)) {
         await shiftDependentPhaseDates(
@@ -923,22 +911,22 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
           updatedPhase,
           actualEndTime - scheduledEndTime,
           currentUserId
-        );
+        )
       }
     }
-    if (data["constraints"]) {
-      for (const constraint of data["constraints"]) {
+    if (data.constraints) {
+      for (const constraint of data.constraints) {
         if (constraint.id) {
           await tx.challengePhaseConstraint.update({
             data: {
               name: constraint.name,
               value: constraint.value,
-              updatedBy: currentUserId,
+              updatedBy: currentUserId
             },
             where: {
-              id: constraint.id,
-            },
-          });
+              id: constraint.id
+            }
+          })
         } else {
           await tx.challengePhaseConstraint.create({
             data: {
@@ -946,104 +934,101 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
               value: constraint.value,
               challengePhaseId: updatedPhase.id,
               createdBy: currentUserId,
-              updatedBy: currentUserId,
-            },
-          });
+              updatedBy: currentUserId
+            }
+          })
         }
       }
     }
     if (shouldRefreshPhaseNames) {
       const openPhases = await tx.challengePhase.findMany({
         where: { challengeId, isOpen: true },
-        select: { name: true },
-      });
+        select: { name: true }
+      })
       const currentPhaseNames = _.uniq(
         openPhases.map((phase) => phase.name).filter((name) => !_.isNil(name))
-      );
+      )
       await tx.challenge.update({
         where: { id: challengeId },
         data: {
           currentPhaseNames,
-          updatedBy: currentUserId,
-        },
-      });
+          updatedBy: currentUserId
+        }
+      })
     }
-    return updatedPhase;
-  });
-  helper.flushInternalCache();
+    return updatedPhase
+  })
+  helper.flushInternalCache()
   // post bus event
   await helper.postBusEvent(
     constants.Topics.ChallengePhaseUpdated,
     _.assignIn({ id: result.id }, data)
-  );
-  await postChallengeUpdatedNotification(challengeId);
+  )
+  await postChallengeUpdatedNotification(challengeId)
 
   // send notification logic
   try {
-    const shouldNotifyClose = Boolean(isClosingPhase);
-    const shouldNotifyOpen = Boolean(isOpeningPhase); // includes reopen
+    const shouldNotifyClose = Boolean(isClosingPhase)
+    const shouldNotifyOpen = Boolean(isOpeningPhase) // includes reopen
 
     if (shouldNotifyClose || shouldNotifyOpen) {
       // Single template - single type
-      const notificationType = "PHASE_CHANGE";
+      const notificationType = 'PHASE_CHANGE'
 
-      const operation = shouldNotifyClose
-        ? "close"
-        : (isReopeningPhase ? "reopen" : "open");
+      const operation = shouldNotifyClose ? 'close' : isReopeningPhase ? 'reopen' : 'open'
 
       const at = shouldNotifyClose
-        ? (result.actualEndDate || new Date().toISOString())
-        : (result.actualStartDate || new Date().toISOString());
+        ? result.actualEndDate || new Date().toISOString()
+        : result.actualStartDate || new Date().toISOString()
 
       // fetch challenge name
       const challenge = await prisma.challenge.findUnique({
         where: { id: challengeId },
-        select: { name: true },
-      });
+        select: { name: true }
+      })
 
-      const challengeName = challenge?.name;
+      const challengeName = challenge?.name
 
       // build recipients
-      const resources = await helper.getChallengeResources(challengeId);
+      const resources = await helper.getChallengeResources(challengeId)
 
       const recipients = Array.from(
         new Set(
           (resources || [])
-            .map(r => r?.email || r?.memberEmail)
+            .map((r) => r?.email || r?.memberEmail)
             .filter(Boolean)
-            .map(e => String(e).trim().toLowerCase())
+            .map((e) => String(e).trim().toLowerCase())
         )
-      );
+      )
 
       if (!recipients.length) {
         logger.debug(
           `phase change notification skipped: no recipients for challenge ${challengeId}`
-        );
-        return _.omit(result, constants.auditFields);
+        )
+        return _.omit(result, constants.auditFields)
       }
 
       // build payload that matches the SendGrid HTML template
-      const phaseName = result.name || data.name || challengePhase.name;
+      const phaseName = result.name || data.name || challengePhase.name
 
       const payload = helper.buildPhaseChangeEmailData({
         challengeId,
         challengeName,
         phaseName,
         operation,
-        at,
-      });
+        at
+      })
 
-      await helper.sendPhaseChangeNotification(notificationType, recipients, payload);
+      await helper.sendPhaseChangeNotification(notificationType, recipients, payload)
     }
   } catch (e) {
     logger.debug(
       `phase change notification failed for challenge ${challengeId}, phase ${id}: ${e.message}`
-    );
+    )
   }
 
-  return _.omit(result, constants.auditFields);
+  return _.omit(result, constants.auditFields)
 }
-
 
 partiallyUpdateChallengePhase.schema = {
   currentUser: Joi.any(),
@@ -1066,12 +1051,12 @@ partiallyUpdateChallengePhase.schema = {
         Joi.object({
           id: Joi.any().optional(),
           name: Joi.string().required(),
-          value: Joi.number().integer().min(0).required(),
+          value: Joi.number().integer().min(0).required()
         })
       )
-      .optional(),
-  }),
-};
+      .optional()
+  })
+}
 
 /**
  * Delete challenge phase.
@@ -1080,15 +1065,15 @@ partiallyUpdateChallengePhase.schema = {
  * @param {String} id the phase id
  * @returns {Object} the deleted challenge phase
  */
-async function deleteChallengePhase(currentUser, challengeId, id) {
-  await checkChallengeExists(challengeId);
+async function deleteChallengePhase (currentUser, challengeId, id) {
+  await checkChallengeExists(challengeId)
   const result = await prisma.challengePhase.findFirst({
-    where: { challengeId, id },
-  });
+    where: { challengeId, id }
+  })
   if (!result) {
     throw new errors.NotFoundError(
       `ChallengePhase with challengeId: ${challengeId},  phaseId: ${id} doesn't exist`
-    );
+    )
   }
   await prisma.$transaction(async (tx) => {
     // recalculates the predecessors
@@ -1097,45 +1082,45 @@ async function deleteChallengePhase(currentUser, challengeId, id) {
         // if result.predecessor exists, update successor's predecessor to predecessor of current challenge phase
         // otherwise update successor's predecessor to null
         predecessor: result.predecessor || null,
-        updatedBy: String(currentUser.userId),
+        updatedBy: String(currentUser.userId)
       },
       where: {
         challengeId,
-        predecessor: result.id,
-      },
-    });
+        predecessor: result.id
+      }
+    })
     // delete challengePhaseConstraint
     await tx.challengePhaseConstraint.deleteMany({
       where: {
-        challengePhaseId: result.id,
-      },
-    });
+        challengePhaseId: result.id
+      }
+    })
     // delete challengePhase
     await tx.challengePhase.delete({
       where: {
-        id: result.id,
-      },
-    });
-  });
-  helper.flushInternalCache();
-  const ret = _.omit(result, constants.auditFields);
+        id: result.id
+      }
+    })
+  })
+  helper.flushInternalCache()
+  const ret = _.omit(result, constants.auditFields)
   // post bus event
-  await helper.postBusEvent(constants.Topics.ChallengePhaseDeleted, ret);
-  await postChallengeUpdatedNotification(challengeId);
-  return ret;
+  await helper.postBusEvent(constants.Topics.ChallengePhaseDeleted, ret)
+  await postChallengeUpdatedNotification(challengeId)
+  return ret
 }
 
 deleteChallengePhase.schema = {
   currentUser: Joi.any(),
   challengeId: Joi.id(),
-  id: Joi.id(),
-};
+  id: Joi.id()
+}
 
 module.exports = {
   getAllChallengePhases,
   getChallengePhase,
   partiallyUpdateChallengePhase,
-  deleteChallengePhase,
-};
+  deleteChallengePhase
+}
 
-logger.buildService(module.exports);
+logger.buildService(module.exports)

--- a/test/unit/ChallengePhaseService.test.js
+++ b/test/unit/ChallengePhaseService.test.js
@@ -9,9 +9,12 @@ require('../../app-bootstrap')
 const chai = require('chai')
 const config = require('config')
 const { Prisma } = require('@prisma/client')
-const { v4: uuid } = require('uuid');
+const { v4: uuid } = require('uuid')
+const challengeService = require('../../src/services/ChallengeService')
 const { getReviewClient } = require('../../src/common/review-prisma')
 const prisma = require('../../src/common/prisma').getClient()
+const originalIndexChallengeAndPostToKafka = challengeService.indexChallengeAndPostToKafka
+challengeService.indexChallengeAndPostToKafka = async () => {}
 const service = require('../../src/services/ChallengePhaseService')
 const helper = require('../../src/common/helper')
 const testHelper = require('../testHelper')
@@ -29,6 +32,67 @@ describe('challenge phase service unit tests', () => {
   const appealTable = Prisma.raw(`"${reviewSchema}"."appeal"`)
   let reviewClient
   const shortId = () => uuid().replace(/-/g, '').slice(0, 14)
+  const resetPrimaryChallengePhases = async () => {
+    await prisma.challengePhaseConstraint.update({
+      where: { id: data.challengePhaseConstrain1Id },
+      data: {
+        name: 'constraint-name-1',
+        value: 100,
+        updatedBy: 'admin'
+      }
+    })
+    await prisma.challengePhaseConstraint.updateMany({
+      where: { challengePhaseId: data.challengePhase2Id },
+      data: {
+        name: 'constraint-name-2',
+        value: 200,
+        updatedBy: 'admin'
+      }
+    })
+    await prisma.challengePhase.update({
+      where: { id: data.challengePhase1Id },
+      data: {
+        phaseId: data.phase.id,
+        name: 'Registration',
+        duration: 1000,
+        predecessor: null,
+        isOpen: false,
+        scheduledStartDate: null,
+        scheduledEndDate: null,
+        actualStartDate: null,
+        actualEndDate: null,
+        updatedBy: 'admin'
+      }
+    })
+    await prisma.challengePhase.update({
+      where: { id: data.challengePhase2Id },
+      data: {
+        phaseId: data.phase2.id,
+        name: 'Submission',
+        duration: 2000,
+        predecessor: data.challengePhase1Id,
+        isOpen: false,
+        scheduledStartDate: null,
+        scheduledEndDate: null,
+        actualStartDate: null,
+        actualEndDate: null,
+        updatedBy: 'admin'
+      }
+    })
+    await prisma.challenge.update({
+      where: { id: data.challenge.id },
+      data: {
+        currentPhaseNames: [],
+        updatedBy: 'admin'
+      }
+    })
+    await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."appealResponse"`)
+    await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."appeal"`)
+    await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."reviewItemComment"`)
+    await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."reviewItem"`)
+    await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."review"`)
+    await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."submission"`)
+  }
   before(async () => {
     await testHelper.createData()
     data = testHelper.getData()
@@ -90,6 +154,8 @@ describe('challenge phase service unit tests', () => {
   })
 
   after(async () => {
+    challengeService.indexChallengeAndPostToKafka = originalIndexChallengeAndPostToKafka
+
     if (reviewClient) {
       await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."appealResponse"`)
       await reviewClient.$executeRawUnsafe(`TRUNCATE TABLE "${reviewSchema}"."appeal"`)
@@ -152,7 +218,10 @@ describe('challenge phase service unit tests', () => {
       try {
         await service.getChallengePhase(data.taskChallenge.id, data.challengePhase2Id)
       } catch (e) {
-        should.equal(e.message, `ChallengePhase with challengeId: ${data.taskChallenge.id},  phaseId: ${data.challengePhase2Id} doesn't exist`)
+        should.equal(
+          e.message,
+          `ChallengePhase with challengeId: ${data.taskChallenge.id},  phaseId: ${data.challengePhase2Id} doesn't exist`
+        )
         return
       }
       throw new Error('should not reach here')
@@ -180,32 +249,46 @@ describe('challenge phase service unit tests', () => {
   })
 
   describe('partially update challenge phase tests', () => {
+    beforeEach(async () => {
+      await resetPrimaryChallengePhases()
+    })
+
     it('partially update challenge phase successfully', async function () {
       this.timeout(50000)
       const scheduledStartDate = '2025-01-01T00:00:00.000Z'
-      const expectedScheduledEndDate = new Date(new Date(scheduledStartDate).getTime() + 7200 * 1000).toISOString()
-      const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-        name: 'updated-Registration',
-        isOpen: true,
-        duration: 7200,
-        scheduledStartDate,
-        constraints: [
-          {
-            id: data.challengePhaseConstrain1Id,
-            name: 'u1',
-            value: 10
-          },
-          {
-            name: 'i1',
-            value: 20
-          }
-        ]
-      })
+      const expectedScheduledEndDate = new Date(
+        new Date(scheduledStartDate).getTime() + 7200 * 1000
+      ).toISOString()
+      const challengePhase = await service.partiallyUpdateChallengePhase(
+        authUser,
+        data.challenge.id,
+        data.challengePhase1Id,
+        {
+          name: 'updated-Registration',
+          isOpen: true,
+          duration: 7200,
+          scheduledStartDate,
+          constraints: [
+            {
+              id: data.challengePhaseConstrain1Id,
+              name: 'u1',
+              value: 10
+            },
+            {
+              name: 'i1',
+              value: 20
+            }
+          ]
+        }
+      )
       should.equal(challengePhase.name, 'updated-Registration')
       should.equal(challengePhase.duration, 7200)
       should.equal(challengePhase.isOpen, true)
       should.equal(new Date(challengePhase.scheduledStartDate).toISOString(), scheduledStartDate)
-      should.equal(new Date(challengePhase.scheduledEndDate).toISOString(), expectedScheduledEndDate)
+      should.equal(
+        new Date(challengePhase.scheduledEndDate).toISOString(),
+        expectedScheduledEndDate
+      )
     })
 
     it('partially update challenge phase - closing sets actual end date', async () => {
@@ -215,9 +298,14 @@ describe('challenge phase service unit tests', () => {
       })
 
       const before = new Date()
-      const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-        isOpen: false
-      })
+      const challengePhase = await service.partiallyUpdateChallengePhase(
+        authUser,
+        data.challenge.id,
+        data.challengePhase1Id,
+        {
+          isOpen: false
+        }
+      )
       const after = new Date()
 
       should.equal(challengePhase.isOpen, false)
@@ -295,7 +383,8 @@ describe('challenge phase service unit tests', () => {
         const actualEndMs = new Date(challengePhase.actualEndDate).getTime()
         const successorStartMs = new Date(successorPhase.scheduledStartDate).getTime()
         const successorEndMs = new Date(successorPhase.scheduledEndDate).getTime()
-        const aiScreeningDurationMs = aiScreeningScheduledEndDate.getTime() - aiScreeningScheduledStartDate.getTime()
+        const aiScreeningDurationMs =
+          aiScreeningScheduledEndDate.getTime() - aiScreeningScheduledStartDate.getTime()
 
         actualEndMs.should.be.at.least(before.getTime())
         actualEndMs.should.be.at.most(after.getTime())
@@ -319,9 +408,14 @@ describe('challenge phase service unit tests', () => {
       })
 
       const before = new Date()
-      const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-        isOpen: true
-      })
+      const challengePhase = await service.partiallyUpdateChallengePhase(
+        authUser,
+        data.challenge.id,
+        data.challengePhase1Id,
+        {
+          isOpen: true
+        }
+      )
       const after = new Date()
 
       should.equal(challengePhase.isOpen, true)
@@ -352,9 +446,14 @@ describe('challenge phase service unit tests', () => {
         }
       })
 
-      const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-        isOpen: true
-      })
+      const challengePhase = await service.partiallyUpdateChallengePhase(
+        authUser,
+        data.challenge.id,
+        data.challengePhase1Id,
+        {
+          isOpen: true
+        }
+      )
 
       should.equal(challengePhase.isOpen, true)
       should.equal(challengePhase.actualEndDate, null)
@@ -414,9 +513,59 @@ describe('challenge phase service unit tests', () => {
       }
     })
 
-    it('partially update challenge phase - can reopen registration when submission is open', async () => {
+    it('partially update challenge phase - cannot reopen registration when open submission depends on checkpoint review', async () => {
       const startDate = new Date('2025-06-01T00:00:00.000Z')
       const endDate = new Date('2025-06-02T00:00:00.000Z')
+      const checkpointReviewPhase = await prisma.phase.create({
+        data: {
+          id: uuid(),
+          name: 'Checkpoint Review',
+          description: 'desc',
+          isOpen: false,
+          duration: 3600,
+          createdBy: 'admin',
+          updatedBy: 'admin'
+        }
+      })
+      const checkpointReviewChallengePhaseId = uuid()
+      const checkpointReviewStartDate = new Date('2025-06-02T00:00:00.000Z')
+      const checkpointReviewEndDate = new Date('2025-06-03T00:00:00.000Z')
+      const registrationOriginalData = await prisma.challengePhase.findUnique({
+        where: { id: data.challengePhase1Id },
+        select: {
+          actualEndDate: true,
+          actualStartDate: true,
+          isOpen: true,
+          name: true,
+          predecessor: true
+        }
+      })
+      const submissionOriginalData = await prisma.challengePhase.findUnique({
+        where: { id: data.challengePhase2Id },
+        select: {
+          actualEndDate: true,
+          actualStartDate: true,
+          isOpen: true,
+          name: true,
+          predecessor: true
+        }
+      })
+
+      await prisma.challengePhase.create({
+        data: {
+          id: checkpointReviewChallengePhaseId,
+          challengeId: data.challenge.id,
+          phaseId: checkpointReviewPhase.id,
+          name: 'Checkpoint Review',
+          duration: 1000,
+          isOpen: false,
+          predecessor: data.phase.id,
+          actualStartDate: checkpointReviewStartDate,
+          actualEndDate: checkpointReviewEndDate,
+          createdBy: 'admin',
+          updatedBy: 'admin'
+        }
+      })
 
       await prisma.challengePhase.update({
         where: { id: data.challengePhase1Id },
@@ -430,12 +579,14 @@ describe('challenge phase service unit tests', () => {
         where: { id: data.challengePhase2Id },
         data: {
           isOpen: true,
-          predecessor: null
+          actualStartDate: checkpointReviewEndDate,
+          actualEndDate: null,
+          predecessor: checkpointReviewPhase.id
         }
       })
 
       try {
-        const challengePhase = await service.partiallyUpdateChallengePhase(
+        await service.partiallyUpdateChallengePhase(
           authUser,
           data.challenge.id,
           data.challengePhase1Id,
@@ -443,31 +594,30 @@ describe('challenge phase service unit tests', () => {
             isOpen: true
           }
         )
-        should.equal(challengePhase.id, data.challengePhase1Id)
-        should.equal(challengePhase.isOpen, true)
-        should.equal(challengePhase.actualEndDate, null)
+      } catch (e) {
+        should.equal(e.httpStatus || e.statusCode, 403)
+        should.equal(
+          e.message,
+          'Cannot reopen Registration because no currently open phase depends on it'
+        )
+        return
       } finally {
         await prisma.challengePhase.update({
-          where: { id: data.challengePhase1Id },
-          data: {
-            isOpen: false,
-            actualStartDate: startDate,
-            actualEndDate: endDate
-          }
+          where: { id: data.challengePhase2Id },
+          data: submissionOriginalData
         })
         await prisma.challengePhase.update({
-          where: { id: data.challengePhase2Id },
-          data: {
-            isOpen: false,
-            predecessor: data.challengePhase1Id,
-            name: 'Submission'
-          }
+          where: { id: data.challengePhase1Id },
+          data: registrationOriginalData
         })
+        await prisma.challengePhase.delete({ where: { id: checkpointReviewChallengePhaseId } })
+        await prisma.phase.delete({ where: { id: checkpointReviewPhase.id } })
       }
 
+      throw new Error('should not reach here')
     })
 
-    it('partially update challenge phase - cannot reopen when open phase is not a successor or submission variant', async () => {
+    it('partially update challenge phase - cannot reopen when open phase is not a successor', async () => {
       const startDate = new Date('2025-06-01T00:00:00.000Z')
       const endDate = new Date('2025-06-02T00:00:00.000Z')
 
@@ -489,9 +639,14 @@ describe('challenge phase service unit tests', () => {
       })
 
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-          isOpen: true
-        })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          {
+            isOpen: true
+          }
+        )
       } catch (e) {
         should.equal(e.httpStatus || e.statusCode, 403)
         should.equal(
@@ -570,9 +725,14 @@ describe('challenge phase service unit tests', () => {
       )
 
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-          isOpen: true
-        })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          {
+            isOpen: true
+          }
+        )
       } catch (e) {
         should.equal(e.httpStatus || e.statusCode, 400)
         should.equal(
@@ -581,7 +741,9 @@ describe('challenge phase service unit tests', () => {
         )
         return
       } finally {
-        await reviewClient.$executeRaw(Prisma.sql`DELETE FROM ${reviewTable} WHERE "id" = ${reviewId}`)
+        await reviewClient.$executeRaw(
+          Prisma.sql`DELETE FROM ${reviewTable} WHERE "id" = ${reviewId}`
+        )
         await prisma.challengePhase.delete({ where: { id: reviewChallengePhaseId } })
         await prisma.phase.delete({ where: { id: reviewPhase.id } })
         await prisma.challengePhase.update({
@@ -685,11 +847,25 @@ describe('challenge phase service unit tests', () => {
           VALUES (${appealId}, ${reviewItemCommentId})
         `
       )
+      const originalGetChallengeResources = helper.getChallengeResources
+      const originalGetResourceRoles = helper.getResourceRoles
+      helper.getChallengeResources = async () => [
+        {
+          roleId: 'reviewer-role-id',
+          resourceRole: { name: 'Reviewer' }
+        }
+      ]
+      helper.getResourceRoles = async () => [{ id: 'reviewer-role-id', name: 'Reviewer' }]
 
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, reviewChallengePhaseId, {
-          isOpen: true
-        })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          reviewChallengePhaseId,
+          {
+            isOpen: true
+          }
+        )
       } catch (e) {
         should.equal(e.httpStatus || e.statusCode, 403)
         should.equal(
@@ -698,13 +874,23 @@ describe('challenge phase service unit tests', () => {
         )
         return
       } finally {
-        await reviewClient.$executeRaw(Prisma.sql`DELETE FROM ${appealTable} WHERE "id" = ${appealId}`)
+        await reviewClient.$executeRaw(
+          Prisma.sql`DELETE FROM ${appealTable} WHERE "id" = ${appealId}`
+        )
         await reviewClient.$executeRaw(
           Prisma.sql`DELETE FROM ${reviewItemCommentTable} WHERE "id" = ${reviewItemCommentId}`
         )
-        await reviewClient.$executeRaw(Prisma.sql`DELETE FROM ${reviewItemTable} WHERE "id" = ${reviewItemId}`)
-        await reviewClient.$executeRaw(Prisma.sql`DELETE FROM ${reviewTable} WHERE "id" = ${reviewId}`)
-        await reviewClient.$executeRaw(Prisma.sql`DELETE FROM ${submissionTable} WHERE "id" = ${submissionId}`)
+        await reviewClient.$executeRaw(
+          Prisma.sql`DELETE FROM ${reviewItemTable} WHERE "id" = ${reviewItemId}`
+        )
+        await reviewClient.$executeRaw(
+          Prisma.sql`DELETE FROM ${reviewTable} WHERE "id" = ${reviewId}`
+        )
+        await reviewClient.$executeRaw(
+          Prisma.sql`DELETE FROM ${submissionTable} WHERE "id" = ${submissionId}`
+        )
+        helper.getChallengeResources = originalGetChallengeResources
+        helper.getResourceRoles = originalGetResourceRoles
         await prisma.challengePhase.deleteMany({
           where: { id: { in: [appealsChallengePhaseId, reviewChallengePhaseId] } }
         })
@@ -716,9 +902,17 @@ describe('challenge phase service unit tests', () => {
 
     it('partially update challenge phase - not found', async () => {
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.taskChallenge.id, data.challengePhase2Id, { name: 'updated', duration: 7200 })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.taskChallenge.id,
+          data.challengePhase2Id,
+          { name: 'updated', duration: 7200 }
+        )
       } catch (e) {
-        should.equal(e.message, `ChallengePhase with challengeId: ${data.taskChallenge.id},  phaseId: ${data.challengePhase2Id} doesn't exist`)
+        should.equal(
+          e.message,
+          `ChallengePhase with challengeId: ${data.taskChallenge.id},  phaseId: ${data.challengePhase2Id} doesn't exist`
+        )
         return
       }
       throw new Error('should not reach here')
@@ -726,7 +920,12 @@ describe('challenge phase service unit tests', () => {
 
     it('partially update challenge phase - phaseId does not exist', async () => {
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, { name: 'updated', phaseId: data.challenge.id, isOpen: null })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          { name: 'updated', phaseId: data.challenge.id, isOpen: null }
+        )
       } catch (e) {
         should.equal(e.message, 'phaseId should be a valid phase')
         return
@@ -736,7 +935,12 @@ describe('challenge phase service unit tests', () => {
 
     it('partially update challenge phase - predecessor does not exist', async () => {
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, { name: 'updated', predecessor: data.challenge.id })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          { name: 'updated', predecessor: data.challenge.id }
+        )
       } catch (e) {
         should.equal(
           e.message,
@@ -751,9 +955,17 @@ describe('challenge phase service unit tests', () => {
       const startDate = '2025-04-04T04:38:00.000Z'
       const endDate = '2025-04-03T04:38:00.000Z'
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, { name: 'updated', scheduledStartDate: startDate, scheduledEndDate: endDate })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          { name: 'updated', scheduledStartDate: startDate, scheduledEndDate: endDate }
+        )
       } catch (e) {
-        should.equal(e.message, `scheduledStartDate: ${startDate} should not be after scheduledEndDate: ${endDate}`)
+        should.equal(
+          e.message,
+          `scheduledStartDate: ${startDate} should not be after scheduledEndDate: ${endDate}`
+        )
         return
       }
       throw new Error('should not reach here')
@@ -763,9 +975,17 @@ describe('challenge phase service unit tests', () => {
       const startDate = '2025-04-04T04:38:00.000Z'
       const endDate = '2025-04-03T04:38:00.000Z'
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, { name: 'updated', actualStartDate: startDate, actualEndDate: endDate })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          { name: 'updated', actualStartDate: startDate, actualEndDate: endDate }
+        )
       } catch (e) {
-        should.equal(e.message, `actualStartDate: ${startDate} should not be after actualEndDate: ${endDate}`)
+        should.equal(
+          e.message,
+          `actualStartDate: ${startDate} should not be after actualEndDate: ${endDate}`
+        )
         return
       }
       throw new Error('should not reach here')
@@ -773,16 +993,26 @@ describe('challenge phase service unit tests', () => {
 
     it('partially update challenge phase - constraint is not exists for the ChallengePhase', async () => {
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-          name: 'updated',
-          constraints: [{
-            id: data.challenge.id,
-            name: 't1',
-            value: 100
-          }]
-        })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          {
+            name: 'updated',
+            constraints: [
+              {
+                id: data.challenge.id,
+                name: 't1',
+                value: 100
+              }
+            ]
+          }
+        )
       } catch (e) {
-        should.equal(e.message, `constraint: ${data.challenge.id} is not exists for the ChallengePhase`)
+        should.equal(
+          e.message,
+          `constraint: ${data.challenge.id} is not exists for the ChallengePhase`
+        )
         return
       }
       throw new Error('should not reach here')
@@ -806,9 +1036,14 @@ describe('challenge phase service unit tests', () => {
           `
         )
 
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-          isOpen: false
-        })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          {
+            isOpen: false
+          }
+        )
       } catch (e) {
         caughtError = e
       } finally {
@@ -819,7 +1054,10 @@ describe('challenge phase service unit tests', () => {
 
       should.exist(caughtError)
       should.equal(caughtError.httpStatus || caughtError.statusCode, 403)
-      should.equal(caughtError.message, 'Cannot close Registration because there are still pending scorecards')
+      should.equal(
+        caughtError.message,
+        'Cannot close Registration because there are still pending scorecards'
+      )
     })
 
     it('partially update challenge phase - allows closing when scorecards are completed', async function () {
@@ -839,9 +1077,14 @@ describe('challenge phase service unit tests', () => {
           `
         )
 
-        const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, {
-          isOpen: false
-        })
+        const challengePhase = await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          {
+            isOpen: false
+          }
+        )
         should.equal(challengePhase.isOpen, false)
       } finally {
         await reviewClient.$executeRaw(
@@ -910,7 +1153,9 @@ describe('challenge phase service unit tests', () => {
 
       const reviewEndDate = new Date(reviewStartDate.getTime() + reviewDuration * 1000)
       const appealsEndDate = new Date(reviewEndDate.getTime() + appealsDuration * 1000)
-      const appealsResponseEndDate = new Date(appealsEndDate.getTime() + appealsResponseDuration * 1000)
+      const appealsResponseEndDate = new Date(
+        appealsEndDate.getTime() + appealsResponseDuration * 1000
+      )
       const approvalEndDate = new Date(appealsResponseEndDate.getTime() + approvalDuration * 1000)
 
       await prisma.challengePhase.createMany({
@@ -1016,10 +1261,23 @@ describe('challenge phase service unit tests', () => {
         should.equal(new Date(updatedApproval.scheduledEndDate).toISOString(), expectedApprovalEnd)
       } finally {
         await prisma.challengePhase.deleteMany({
-          where: { id: { in: [reviewChallengePhaseId, appealsChallengePhaseId, appealsResponseChallengePhaseId, approvalChallengePhaseId] } }
+          where: {
+            id: {
+              in: [
+                reviewChallengePhaseId,
+                appealsChallengePhaseId,
+                appealsResponseChallengePhaseId,
+                approvalChallengePhaseId
+              ]
+            }
+          }
         })
         await prisma.phase.deleteMany({
-          where: { id: { in: [reviewPhase.id, appealsPhase.id, appealsResponsePhase.id, approvalPhase.id] } }
+          where: {
+            id: {
+              in: [reviewPhase.id, appealsPhase.id, appealsResponsePhase.id, approvalPhase.id]
+            }
+          }
         })
       }
     })
@@ -1146,9 +1404,14 @@ describe('challenge phase service unit tests', () => {
 
     it('partially update challenge phase - unexpected field', async () => {
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, { name: 'xx', other: 'xx' })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase1Id,
+          { name: 'xx', other: 'xx' }
+        )
       } catch (e) {
-        should.equal(e.message.indexOf('"other" is not allowed') >= 0, true)
+        should.equal(e.message.indexOf('"data.other" is not allowed') >= 0, true)
         return
       }
       throw new Error('should not reach here')
@@ -1161,7 +1424,12 @@ describe('challenge phase service unit tests', () => {
       })
 
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase2Id, { isOpen: true })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase2Id,
+          { isOpen: true }
+        )
       } catch (e) {
         should.equal(
           e.message,
@@ -1184,7 +1452,12 @@ describe('challenge phase service unit tests', () => {
       })
 
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase2Id, { isOpen: true })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase2Id,
+          { isOpen: true }
+        )
       } catch (e) {
         should.equal(
           e.message,
@@ -1207,7 +1480,12 @@ describe('challenge phase service unit tests', () => {
       })
 
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase2Id, { isOpen: true })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          data.challengePhase2Id,
+          { isOpen: true }
+        )
       } catch (e) {
         should.equal(
           e.message,
@@ -1234,7 +1512,12 @@ describe('challenge phase service unit tests', () => {
         data: { isOpen: false }
       })
 
-      const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase2Id, { isOpen: true })
+      const challengePhase = await service.partiallyUpdateChallengePhase(
+        authUser,
+        data.challenge.id,
+        data.challengePhase2Id,
+        { isOpen: true }
+      )
       should.equal(challengePhase.isOpen, true)
     })
 
@@ -1248,7 +1531,12 @@ describe('challenge phase service unit tests', () => {
         }
       })
 
-      const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, data.challengePhase1Id, { isOpen: true })
+      const challengePhase = await service.partiallyUpdateChallengePhase(
+        authUser,
+        data.challenge.id,
+        data.challengePhase1Id,
+        { isOpen: true }
+      )
       should.equal(challengePhase.isOpen, true)
     })
 
@@ -1279,15 +1567,16 @@ describe('challenge phase service unit tests', () => {
 
       const originalGetChallengeResources = helper.getChallengeResources
       const originalGetResourceRoles = helper.getResourceRoles
-      helper.getChallengeResources = async () => ([
-        { roleId: 'some-other-role-id' }
-      ])
-      helper.getResourceRoles = async () => ([
-        { id: 'reviewer-role-id', name: 'Reviewer' }
-      ])
+      helper.getChallengeResources = async () => [{ roleId: 'some-other-role-id' }]
+      helper.getResourceRoles = async () => [{ id: 'reviewer-role-id', name: 'Reviewer' }]
 
       try {
-        await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, reviewChallengePhaseId, { isOpen: true })
+        await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          reviewChallengePhaseId,
+          { isOpen: true }
+        )
       } catch (e) {
         should.equal(e.httpStatus || e.statusCode, 400)
         should.equal(
@@ -1332,18 +1621,21 @@ describe('challenge phase service unit tests', () => {
 
       const originalGetChallengeResources = helper.getChallengeResources
       const originalGetResourceRoles = helper.getResourceRoles
-      helper.getChallengeResources = async () => ([
+      helper.getChallengeResources = async () => [
         {
           roleId: 'reviewer-role-id',
           resourceRole: { name: 'Reviewer' }
         }
-      ])
-      helper.getResourceRoles = async () => ([
-        { id: 'reviewer-role-id', name: 'Reviewer' }
-      ])
+      ]
+      helper.getResourceRoles = async () => [{ id: 'reviewer-role-id', name: 'Reviewer' }]
 
       try {
-        const challengePhase = await service.partiallyUpdateChallengePhase(authUser, data.challenge.id, reviewChallengePhaseId, { isOpen: true })
+        const challengePhase = await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          reviewChallengePhaseId,
+          { isOpen: true }
+        )
         should.equal(challengePhase.isOpen, true)
       } finally {
         helper.getChallengeResources = originalGetChallengeResources
@@ -1366,7 +1658,10 @@ describe('challenge phase service unit tests', () => {
       try {
         await service.deleteChallengePhase(authUser, data.taskChallenge.id, data.challengePhase1Id)
       } catch (e) {
-        should.equal(e.message, `ChallengePhase with challengeId: ${data.taskChallenge.id},  phaseId: ${data.challengePhase1Id} doesn't exist`)
+        should.equal(
+          e.message,
+          `ChallengePhase with challengeId: ${data.taskChallenge.id},  phaseId: ${data.challengePhase1Id} doesn't exist`
+        )
         return
       }
       throw new Error('should not reach here')


### PR DESCRIPTION
What was broken
challenge-api-v6 still allowed Registration to be reopened whenever a Submission phase was open, even when that Submission phase depended on Checkpoint Review instead of Registration. That kept surfacing the wrong Reopen action after the earlier platform-ui fix.

Root cause
ChallengePhaseService had a special-case exemption that bypassed explicit dependency checks for Registration whenever any submission variant was open.

What was changed
Removed the submission-based Registration reopen exemption so reopening now requires a real open dependent phase.
Added a regression test for the Checkpoint Review to Submission path.
Stabilized ChallengePhaseService unit setup so the seeded phase records are reset between tests and challenge update publishing is stubbed for this suite.

Any added/updated tests
Added a regression test that forbids reopening Registration when the open Submission phase depends on Checkpoint Review.
Updated ChallengePhaseService unit setup to run the full file reliably in isolation.
