### PR TITLE
PM-4837: Make challenge name search case-insensitive

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -944,7 +944,10 @@ async function searchChallenges(currentUser, criteria) {
   } else {
     if (criteria.name) {
       prismaFilter.where.AND.push({
-        name: { contains: criteria.name },
+        name: {
+          contains: criteria.name,
+          mode: "insensitive",
+        },
       });
     }
 

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -863,6 +863,18 @@ describe("challenge service unit tests", () => {
       should.equal(result.result.length, 0);
     });
 
+    it("search challenges by name case-insensitively", async () => {
+      const result = await service.searchChallenges(
+        { isMachine: true },
+        { name: data.challenge.name.toLowerCase() },
+      );
+
+      should.equal(result.total, 1);
+      should.equal(result.result.length, 1);
+      should.equal(result.result[0].id, data.challenge.id);
+      should.equal(result.result[0].name, data.challenge.name);
+    });
+
     it("search challenges successfully 3", async () => {
       const res = await service.searchChallenges(
         { isMachine: true },


### PR DESCRIPTION
What was broken
Challenge name filtering on the common and project challenge listings only matched names with the same letter casing as the stored challenge name, so searches like `test design` and `Test design` returned different results.

Root cause
The challenges API used Prisma `contains` on PostgreSQL without `mode: "insensitive"` for the `name` filter, which made the name filter case-sensitive.

What was changed
Updated the challenge search query to apply the `name` filter with Prisma's case-insensitive mode.
Added a regression test covering a lowercase query against a mixed-case challenge name.

Any added/updated tests
Added `search challenges by name case-insensitively` to `test/unit/ChallengeService.test.js`.
Validated the new test against a local PostgreSQL schema provisioned from `prisma/schema.prisma`.
