### PR TITLE
PM-4837: Make challenge listing name search case-insensitive

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -926,7 +926,10 @@ async function searchChallenges(currentUser, criteria) {
     prismaFilter.where.AND.push({
       OR: [
         {
-          name: { contains: criteria.search },
+          name: {
+            contains: criteria.search,
+            mode: "insensitive",
+          },
         },
         {
           description: { contains: criteria.search },
@@ -944,7 +947,10 @@ async function searchChallenges(currentUser, criteria) {
   } else {
     if (criteria.name) {
       prismaFilter.where.AND.push({
-        name: { contains: criteria.name },
+        name: {
+          contains: criteria.name,
+          mode: "insensitive",
+        },
       });
     }
 
@@ -2524,7 +2530,7 @@ async function validateChallengeActivationBillingAccount({
 
   if (!normalizedBillingAccountId) {
     throw new errors.BadRequestError(
-      "Cannot activate challenge because the project has no billing account."
+      "Cannot activate challenge because the project has no billing account.",
     );
   }
 
@@ -2533,36 +2539,37 @@ async function validateChallengeActivationBillingAccount({
 
   if (resolvedProjectActive === false) {
     throw new errors.BadRequestError(
-      "Cannot activate challenge because the project billing account is inactive."
+      "Cannot activate challenge because the project billing account is inactive.",
     );
   }
 
   if (isBillingAccountExpired(resolvedProjectActive, resolvedProjectEndDate)) {
     throw new errors.BadRequestError(
-      "Cannot activate challenge because the project billing account is expired."
+      "Cannot activate challenge because the project billing account is expired.",
     );
   }
 
-  const billingAccountDetails = await projectHelper.getBillingAccountDetails(normalizedBillingAccountId);
+  const billingAccountDetails = await projectHelper.getBillingAccountDetails(
+    normalizedBillingAccountId,
+  );
   const resolvedActive = resolveBillingAccountActive(billingAccountDetails);
-  const resolvedEndDate =
-    normalizeOptionalString(_.get(billingAccountDetails, "endDate"));
+  const resolvedEndDate = normalizeOptionalString(_.get(billingAccountDetails, "endDate"));
 
   if (!billingAccountDetails) {
     throw new errors.BadRequestError(
-      "Cannot activate challenge because the project billing account could not be found."
+      "Cannot activate challenge because the project billing account could not be found.",
     );
   }
 
   if (resolvedActive === false) {
     throw new errors.BadRequestError(
-      "Cannot activate challenge because the project billing account is inactive."
+      "Cannot activate challenge because the project billing account is inactive.",
     );
   }
 
   if (isBillingAccountExpired(resolvedActive, resolvedEndDate)) {
     throw new errors.BadRequestError(
-      "Cannot activate challenge because the project billing account is expired."
+      "Cannot activate challenge because the project billing account is expired.",
     );
   }
 
@@ -2570,7 +2577,7 @@ async function validateChallengeActivationBillingAccount({
 
   if (!_.isNil(remainingBudget) && remainingBudget <= 0) {
     throw new errors.BadRequestError(
-      "Cannot activate challenge because the project billing account has insufficient remaining funds."
+      "Cannot activate challenge because the project billing account has insufficient remaining funds.",
     );
   }
 }

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -863,6 +863,30 @@ describe("challenge service unit tests", () => {
       should.equal(result.result.length, 0);
     });
 
+    it("search challenges by name case-insensitively", async () => {
+      const result = await service.searchChallenges(
+        { isMachine: true },
+        { name: data.challenge.name.toLowerCase() },
+      );
+
+      should.equal(result.total, 1);
+      should.equal(result.result.length, 1);
+      should.equal(result.result[0].id, data.challenge.id);
+      should.equal(result.result[0].name, data.challenge.name);
+    });
+
+    it("search challenges by search term case-insensitively for challenge names", async () => {
+      const result = await service.searchChallenges(
+        { isMachine: true },
+        { search: data.challenge.name.toLowerCase() },
+      );
+
+      should.equal(result.total, 1);
+      should.equal(result.result.length, 1);
+      should.equal(result.result[0].id, data.challenge.id);
+      should.equal(result.result[0].name, data.challenge.name);
+    });
+
     it("search challenges successfully 3", async () => {
       const res = await service.searchChallenges(
         { isMachine: true },


### PR DESCRIPTION
What was broken
Challenge listings only matched challenge names when the query casing matched the stored challenge name exactly. The project challenge page used the `name` filter and the common challenge listing used the shared `search` filter, so lowercase queries could miss mixed-case challenge names.

Root cause
The Prisma `contains` filters for challenge name matching were case-sensitive in both the dedicated `name` branch and the shared `search` branch of `searchChallenges`.

What was changed
Updated challenge name matching in `searchChallenges` to use Prisma's case-insensitive mode for both `criteria.name` and the challenge-name portion of `criteria.search`.
Added focused unit coverage for both the project-page `name` filter path and the common-listing `search` filter path.

Any added/updated tests
Updated `test/unit/ChallengeService.test.js` with regression tests covering case-insensitive matching for both `name` and `search` challenge queries.
