### PR TITLE
PM-4957: Trigger finance on challenge cancellation

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -58,6 +58,27 @@ const allowedSortByValues = _.uniq([
   ...Object.keys(sortByAliases),
 ]);
 
+const CANCELLED_CHALLENGE_STATUSES = new Set([
+  ChallengeStatusEnum.CANCELLED,
+  ChallengeStatusEnum.CANCELLED_REQUIREMENTS_INFEASIBLE,
+  ChallengeStatusEnum.CANCELLED_PAYMENT_FAILED,
+  ChallengeStatusEnum.CANCELLED_FAILED_REVIEW,
+  ChallengeStatusEnum.CANCELLED_FAILED_SCREENING,
+  ChallengeStatusEnum.CANCELLED_ZERO_SUBMISSIONS,
+  ChallengeStatusEnum.CANCELLED_WINNER_UNRESPONSIVE,
+  ChallengeStatusEnum.CANCELLED_CLIENT_REQUEST,
+  ChallengeStatusEnum.CANCELLED_ZERO_REGISTRATIONS,
+]);
+
+/**
+ * Determines whether a challenge status is one of the terminal cancelled states.
+ * @param {String} status challenge status from the update payload or stored challenge
+ * @returns {Boolean} true when the status represents a cancelled challenge
+ */
+function isCancelledChallengeStatus(status) {
+  return CANCELLED_CHALLENGE_STATUSES.has(status);
+}
+
 function normalizeStatusSortValue(statusValue) {
   if (_.isNil(statusValue)) {
     return null;
@@ -2792,6 +2813,8 @@ function prepareTaskCompletionData(challenge, challengeResources, data) {
 
 /**
  * Update challenge.
+ * When a challenge transitions to completed task status or a cancelled status,
+ * payment generation is requested after the database update commits.
  * @param {Object} currentUser the user who perform operation
  * @param {String} challengeId the challenge id
  * @param {Object} data the challenge data to be updated
@@ -3005,6 +3028,8 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
 
   let isChallengeBeingActivated = isStatusChangingToActive;
   let isChallengeBeingCancelled = false;
+  const isStatusChangingToCancelled =
+    isCancelledChallengeStatus(data.status) && !isCancelledChallengeStatus(challenge.status);
   if (data.status) {
     if (data.status === ChallengeStatusEnum.ACTIVE) {
       await validateChallengeActivationBillingAccount({
@@ -3015,22 +3040,7 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
       });
     }
 
-    if (
-      _.includes(
-        [
-          ChallengeStatusEnum.CANCELLED,
-          ChallengeStatusEnum.CANCELLED_REQUIREMENTS_INFEASIBLE,
-          ChallengeStatusEnum.CANCELLED_PAYMENT_FAILED,
-          ChallengeStatusEnum.CANCELLED_FAILED_REVIEW,
-          ChallengeStatusEnum.CANCELLED_FAILED_SCREENING,
-          ChallengeStatusEnum.CANCELLED_ZERO_SUBMISSIONS,
-          ChallengeStatusEnum.CANCELLED_WINNER_UNRESPONSIVE,
-          ChallengeStatusEnum.CANCELLED_CLIENT_REQUEST,
-          ChallengeStatusEnum.CANCELLED_ZERO_REGISTRATIONS,
-        ],
-        data.status,
-      )
-    ) {
+    if (isCancelledChallengeStatus(data.status)) {
       isChallengeBeingCancelled = true;
     }
 
@@ -3582,6 +3592,19 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
       }
     } catch (err) {
       logger.error(`Error generating payments for Task challenge ${challengeId}: ${err.message}`);
+    }
+  }
+  if (isStatusChangingToCancelled) {
+    logger.info(`Triggering payment generation for cancelled challenge ${challengeId}`);
+    try {
+      const paymentSuccess = await helper.generateChallengePayments(challengeId);
+      if (!paymentSuccess) {
+        logger.warn(`Failed to generate payments for cancelled challenge ${challengeId}`);
+      }
+    } catch (err) {
+      logger.error(
+        `Error generating payments for cancelled challenge ${challengeId}: ${err.message}`,
+      );
     }
   }
   // Re-fetch the challenge outside the transaction to ensure we publish

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -1800,6 +1800,37 @@ describe("challenge service unit tests", () => {
       }
     });
 
+    it("update challenge - triggers payments when a challenge is cancelled", async () => {
+      const originalGetChallengeResources = helper.getChallengeResources;
+      const originalGenerateChallengePayments = helper.generateChallengePayments;
+      let generatedPaymentsChallengeId;
+      const cancelledChallenge = await createActivationChallenge(ChallengeStatusEnum.ACTIVE);
+
+      helper.getChallengeResources = async () => [];
+      helper.generateChallengePayments = async (challengeId) => {
+        generatedPaymentsChallengeId = challengeId;
+        return true;
+      };
+
+      try {
+        const result = await service.updateChallenge(
+          { isMachine: true, sub: "sub-cancel", userId: 22838965 },
+          cancelledChallenge.id,
+          {
+            status: ChallengeStatusEnum.CANCELLED_CLIENT_REQUEST,
+            cancelReason: "QA cancellation coverage",
+          },
+        );
+
+        should.equal(result.status, ChallengeStatusEnum.CANCELLED_CLIENT_REQUEST);
+        should.equal(generatedPaymentsChallengeId, cancelledChallenge.id);
+      } finally {
+        helper.getChallengeResources = originalGetChallengeResources;
+        helper.generateChallengePayments = originalGenerateChallengePayments;
+        await prisma.challenge.deleteMany({ where: { id: cancelledChallenge.id } });
+      }
+    });
+
     describe("reviewer scorecard changes", () => {
       const originalScorecardId = "sc-original";
       const newScorecardId = "sc-updated";


### PR DESCRIPTION
What was broken
Cancelled challenges in Appeals Response could be saved in challenge-api-v6 without ever calling tc-finance-api, so reviewer payments were not generated and billing-account ledger rows were not updated.

Root cause
The challenge update flow only requested finance payment generation for task challenges transitioning to COMPLETED. Cancelled status transitions reused phase-closing logic but had no matching finance trigger.

What was changed
Added a shared cancelled-status helper in ChallengeService and call finance after a challenge first transitions into any cancelled terminal status. The call runs after the database transaction commits, matching the existing completed-task payment generation pattern and allowing the previously merged finance fix to create reviewer payments or unlock the budget when no payments exist.

Any added/updated tests
Added a ChallengeService unit test that stubs the finance helper and verifies a challenge transitioning to CANCELLED_CLIENT_REQUEST requests payment generation.

Validation notes: pnpm lint passed. pnpm test and the targeted Mocha test could not complete because this checkout has no DATABASE_URL or REVIEW_DB_URL and Docker is not installed to start the documented local Postgres service. pnpm build could not run because package.json has no build script.
