### PR TITLE
PM-4951: Lock draft challenge billing budget

### DIFF
--- a/src/common/project-helper.js
+++ b/src/common/project-helper.js
@@ -248,6 +248,75 @@ class ProjectHelper {
       throw err;
     }
   }
+
+  /**
+   * Locks the current challenge member-payment budget against a billing account.
+   *
+   * The billing-account ledger stores amounts after markup is applied. This
+   * helper accepts the member-payment amount from challenge persistence,
+   * applies the billing markup, and writes one CHALLENGE lock row keyed by the
+   * challenge id.
+   *
+   * @param {object} params Lock request parameters.
+   * @param {string|number} params.billingAccountId Billing-account identifier.
+   * @param {string} params.challengeId Challenge id to use as the external reference.
+   * @param {number|string} params.memberPaymentAmount Challenge member-payment amount before markup.
+   * @param {number|string|null|undefined} params.markup Billing-account markup as a decimal or percentage.
+   * @returns {Promise<object>} Billing Accounts API lock response.
+   * @throws {errors.BadRequestError} When required values are missing or invalid.
+   * @throws {Error} When the Billing Accounts API rejects the lock request.
+   */
+  async lockChallengeBillingAccountAmount({
+    billingAccountId,
+    challengeId,
+    memberPaymentAmount,
+    markup,
+  }) {
+    const normalizedBillingAccountId = normalizeOptionalString(billingAccountId);
+    const normalizedChallengeId = normalizeOptionalString(challengeId);
+    const amount = normalizeOptionalNumber(memberPaymentAmount);
+    const normalizedMarkup = normalizeBillingMarkup(markup) || 0;
+
+    if (!normalizedBillingAccountId) {
+      throw new errors.BadRequestError("Cannot lock challenge budget without a billing account.");
+    }
+
+    if (!normalizedChallengeId) {
+      throw new errors.BadRequestError("Cannot lock challenge budget without a challenge id.");
+    }
+
+    if (_.isNil(amount) || amount < 0) {
+      throw new errors.BadRequestError("Cannot lock challenge budget with an invalid amount.");
+    }
+
+    if (normalizedMarkup < 0) {
+      throw new errors.BadRequestError("Cannot lock challenge budget with an invalid markup.");
+    }
+
+    const token = await m2mHelper.getM2MToken();
+    const lockAmount = Number((amount * (1 + normalizedMarkup)).toFixed(4));
+    const url = `${config.BILLING_ACCOUNTS_API_URL}/${encodeURIComponent(
+      normalizedBillingAccountId
+    )}/lock-amount`;
+    logger.debug(
+      `projectHelper.lockChallengeBillingAccountAmount: PATCH ${url} challengeId=${normalizedChallengeId}`
+    );
+
+    const res = await axios.patch(
+      url,
+      {
+        amount: lockAmount,
+        challengeId: normalizedChallengeId,
+        externalId: normalizedChallengeId,
+        externalType: "CHALLENGE",
+      },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+
+    return res.data;
+  }
 }
 
 module.exports = new ProjectHelper();

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -46,6 +46,11 @@ const BILLING_MARKUP_VISIBLE_ROLES = new Set([
   "talent manager",
   "topcoder talent manager",
 ]);
+const CHALLENGE_BILLING_LOCK_STATUSES = new Set([
+  ChallengeStatusEnum.DRAFT,
+  ChallengeStatusEnum.APPROVED,
+  ChallengeStatusEnum.ACTIVE,
+]);
 
 // Provide aliases for friendlier sortBy query params
 const sortByAliases = {
@@ -87,6 +92,72 @@ function compareStatusSortValues(aStatusValue, bStatusValue) {
   }
 
   return normalizedA.localeCompare(normalizedB);
+}
+
+/**
+ * Determines whether the challenge budget should remain locked.
+ *
+ * @param {string|undefined|null} status Challenge status from the request or persistence.
+ * @returns {boolean} True when the challenge should reserve billing-account budget.
+ */
+function isChallengeBillingLockStatus(status) {
+  return CHALLENGE_BILLING_LOCK_STATUSES.has(normalizeStatusSortValue(status));
+}
+
+/**
+ * Reads the currently persisted challenge prize total.
+ *
+ * @param {object} challenge Challenge model or response object.
+ * @returns {number|undefined} Total member-payment amount before markup.
+ */
+function getChallengeMemberPaymentAmount(challenge) {
+  const totalPrizes = _.get(
+    challenge,
+    "overview.totalPrizes",
+    _.get(challenge, "overviewTotalPrizes"),
+  );
+  const amount = _.toNumber(totalPrizes);
+
+  return Number.isFinite(amount) ? amount : undefined;
+}
+
+/**
+ * Synchronizes the draft/active challenge budget lock to billing accounts.
+ *
+ * The challenge service owns the current estimated member-payment amount while
+ * finance later consumes the finalized payment amount after payment generation.
+ * This keeps draft challenge rows visible as locked budget in billing-account
+ * details until finance moves the row to consumed.
+ *
+ * @param {object} challenge Challenge model or response object after persistence.
+ * @returns {Promise<void>} Resolves after the billing-account lock is written or skipped.
+ * @throws {Error} When the Billing Accounts API rejects the lock request.
+ */
+async function syncChallengeBillingAccountLock(challenge) {
+  if (!isChallengeBillingLockStatus(challenge && challenge.status)) {
+    return;
+  }
+
+  const billing = _.get(challenge, "billing", _.get(challenge, "billingRecord"));
+  const billingAccountId = _.get(billing, "billingAccountId");
+  const hasBillingAccountId = !_.isNil(billingAccountId) && _.toString(billingAccountId).trim();
+  const memberPaymentAmount = getChallengeMemberPaymentAmount(challenge);
+
+  if (!hasBillingAccountId || _.isNil(memberPaymentAmount)) {
+    logger.warn("Skipping challenge billing lock sync due to missing billing context", {
+      challengeId: _.get(challenge, "id"),
+      hasBillingAccountId: Boolean(hasBillingAccountId),
+      hasMemberPaymentAmount: !_.isNil(memberPaymentAmount),
+    });
+    return;
+  }
+
+  await projectHelper.lockChallengeBillingAccountAmount({
+    billingAccountId,
+    challengeId: challenge.id,
+    markup: _.get(billing, "clientBillingRate", _.get(billing, "markup")),
+    memberPaymentAmount,
+  });
 }
 
 /**
@@ -2046,6 +2117,7 @@ async function createChallenge(currentUser, challenge, userToken) {
   prismaHelper.convertModelToResponse(ret);
   await enrichSkillsData(ret);
   enrichChallengeForResponse(ret, track, type);
+  await syncChallengeBillingAccountLock(ret);
 
   // If the challenge is self-service, add the creating user as the "client manager", *not* the manager
   // This is necessary for proper handling of the vanilla embed on the self-service work item dashboard
@@ -3573,6 +3645,7 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
       include: includeReturnFields,
     });
   });
+  await syncChallengeBillingAccountLock(updatedChallenge);
   if (taskCompletionInfo && taskCompletionInfo.shouldTriggerPayments) {
     logger.info(`Triggering payment generation for Task challenge ${challengeId}`);
     try {

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -105,12 +105,50 @@ function isChallengeBillingLockStatus(status) {
 }
 
 /**
- * Reads the currently persisted challenge prize total.
+ * Calculates the billable USD prize-set total for a challenge.
  *
  * @param {object} challenge Challenge model or response object.
- * @returns {number|undefined} Total member-payment amount before markup.
+ * @returns {number|undefined} USD prize-set member-payment amount before markup,
+ * or `undefined` when prize sets are not loaded.
+ */
+function getChallengePrizeSetMemberPaymentAmount(challenge) {
+  const prizeSets = _.get(challenge, "prizeSets");
+
+  if (!Array.isArray(prizeSets)) {
+    return undefined;
+  }
+
+  return prizeSets.reduce((total, prizeSet) => {
+    const prizes = Array.isArray(prizeSet && prizeSet.prizes) ? prizeSet.prizes : [];
+
+    return (
+      total +
+      prizes.reduce((prizeTotal, prize) => {
+        if (_.toString(_.get(prize, "type")).toUpperCase() !== constants.prizeTypes.USD) {
+          return prizeTotal;
+        }
+
+        const prizeValue = _.toNumber(_.get(prize, "value"));
+
+        return Number.isFinite(prizeValue) ? prizeTotal + prizeValue : prizeTotal;
+      }, 0)
+    );
+  }, 0);
+}
+
+/**
+ * Reads the currently persisted challenge member-payment total.
+ *
+ * @param {object} challenge Challenge model or response object.
+ * @returns {number|undefined} Total USD member-payment amount before markup.
  */
 function getChallengeMemberPaymentAmount(challenge) {
+  const prizeSetMemberPaymentAmount = getChallengePrizeSetMemberPaymentAmount(challenge);
+
+  if (!_.isNil(prizeSetMemberPaymentAmount)) {
+    return prizeSetMemberPaymentAmount;
+  }
+
   const totalPrizes = _.get(
     challenge,
     "overview.totalPrizes",
@@ -2916,14 +2954,17 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
       })`,
     );
 
-    if (billingAccountId && _.isUndefined(_.get(challenge, "billing.billingAccountId"))) {
-      // Ensure billingAccountId is a string or null to match Prisma schema
-      if (billingAccountId !== null && billingAccountId !== undefined) {
-        _.set(data, "billing.billingAccountId", String(billingAccountId));
-      } else {
-        _.set(data, "billing.billingAccountId", null);
-      }
-      _.set(data, "billing.markup", _.isNil(markup) ? 0 : markup);
+    const existingBillingAccountId = normalizeOptionalString(
+      _.get(challenge, "billing.billingAccountId"),
+    );
+    const projectBillingAccountId = normalizeOptionalString(billingAccountId);
+    if (projectBillingAccountId && !existingBillingAccountId) {
+      data.billing = {
+        ..._.get(challenge, "billing", {}),
+        ..._.get(data, "billing", {}),
+        billingAccountId: projectBillingAccountId,
+        markup: _.isNil(markup) ? 0 : markup,
+      };
     }
 
     // Make sure the user cannot change the direct project ID
@@ -4300,7 +4341,11 @@ function sanitizeChallenge(challenge) {
     ]);
   }
   if (challenge.billing) {
-    sanitized.billing = _.pick(challenge.billing, ["billingAccountId", "markup"]);
+    sanitized.billing = _.pick(challenge.billing, [
+      "billingAccountId",
+      "markup",
+      "clientBillingRate",
+    ]);
   }
   if (challenge.metadata) {
     sanitized.metadata = _.map(challenge.metadata, (meta) => _.pick(meta, ["name", "value"]));

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -48,6 +48,8 @@ describe("challenge service unit tests", () => {
   let data;
   let testChallengeData;
   let createdChallengeData;
+  let billingLockRequests;
+  let originalLockChallengeBillingAccountAmount;
   const notFoundId = uuid();
   const authUser = {
     userId: "testuser",
@@ -158,6 +160,19 @@ describe("challenge service unit tests", () => {
     };
   });
 
+  beforeEach(() => {
+    billingLockRequests = [];
+    originalLockChallengeBillingAccountAmount = projectHelper.lockChallengeBillingAccountAmount;
+    projectHelper.lockChallengeBillingAccountAmount = async (request) => {
+      billingLockRequests.push(_.cloneDeep(request));
+      return { locked: true };
+    };
+  });
+
+  afterEach(() => {
+    projectHelper.lockChallengeBillingAccountAmount = originalLockChallengeBillingAccountAmount;
+  });
+
   after(async () => {
     const idsToDelete = _.compact([id, id2]);
     if (idsToDelete.length > 0) {
@@ -241,6 +256,42 @@ describe("challenge service unit tests", () => {
       should.exist(result.created);
       should.equal(result.numOfSubmissions, 0);
       should.equal(result.numOfRegistrants, 0);
+    });
+
+    it("locks draft challenge budget when the challenge is saved", async () => {
+      const challengeData = _.cloneDeep(testChallengeData);
+      challengeData.status = ChallengeStatusEnum.DRAFT;
+      challengeData.prizeSets[0].type = PrizeSetTypeEnum.PLACEMENT;
+      challengeData.prizeSets[0].prizes[0].type = constants.prizeTypes.USD;
+      challengeData.prizeSets[0].prizes[0].value = 1000;
+      const originalGetProjectBillingInformation = projectHelper.getProjectBillingInformation;
+
+      projectHelper.getProjectBillingInformation = async () => ({
+        billingAccountId: "80001012",
+        markup: 0.1,
+      });
+
+      let result;
+      try {
+        result = await service.createChallenge(
+          { isMachine: true, sub: "sub", userId: "testuser" },
+          challengeData,
+          config.M2M_FULL_ACCESS_TOKEN,
+        );
+
+        should.equal(billingLockRequests.length, 1);
+        billingLockRequests[0].should.deep.equal({
+          billingAccountId: "80001012",
+          challengeId: result.id,
+          markup: 0.1,
+          memberPaymentAmount: 1000,
+        });
+      } finally {
+        projectHelper.getProjectBillingInformation = originalGetProjectBillingInformation;
+        if (result && result.id) {
+          await prisma.challenge.deleteMany({ where: { id: result.id } });
+        }
+      }
     });
 
     it("create challenge successfully when project directProjectId is a numeric string", async () => {

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -608,7 +608,10 @@ describe("challenge service unit tests", () => {
           createdChallengeData.id,
         );
 
-        should.equal(result.billing.billingAccountId, createdChallengeData.billing.billingAccountId);
+        should.equal(
+          result.billing.billingAccountId,
+          createdChallengeData.billing.billingAccountId,
+        );
         should.equal(_.isUndefined(result.billing.markup), true);
       } finally {
         helper.userHasProjectWriteAccess = originalUserHasProjectWriteAccess;
@@ -1655,6 +1658,118 @@ describe("challenge service unit tests", () => {
       should.exist(result.startDate);
       should.equal(testHelper.getDatesDiff(result.startDate, testChallengeData.startDate), 0);
     });
+
+    it("backfills missing billing and locks draft budget including copilot prizes", async () => {
+      const challengeData = _.cloneDeep(testChallengeData);
+      challengeData.name = `${challengeData.name} Billing Lock ${Date.now()}`;
+      challengeData.legacyId = Math.floor(Math.random() * 1000000);
+      challengeData.status = ChallengeStatusEnum.NEW;
+      challengeData.prizeSets = [
+        {
+          type: PrizeSetTypeEnum.PLACEMENT,
+          description: "placement prizes",
+          prizes: [
+            {
+              description: "placement 1",
+              type: constants.prizeTypes.USD,
+              value: 1000,
+            },
+          ],
+        },
+        {
+          type: PrizeSetTypeEnum.COPILOT,
+          description: "copilot payment",
+          prizes: [
+            {
+              description: "copilot",
+              type: constants.prizeTypes.USD,
+              value: 150,
+            },
+          ],
+        },
+      ];
+
+      const originalGetProject = projectHelper.getProject;
+      const originalGetProjectBillingInformation = projectHelper.getProjectBillingInformation;
+      let billingLookupCount = 0;
+      let createdChallengeId;
+
+      projectHelper.getProject = async () => ({ directProjectId: "33541" });
+      projectHelper.getProjectBillingInformation = async () => {
+        billingLookupCount += 1;
+
+        if (billingLookupCount === 1) {
+          return {
+            billingAccountId: null,
+            markup: null,
+          };
+        }
+
+        return {
+          billingAccountId: "80001012",
+          markup: 0.1,
+        };
+      };
+
+      try {
+        const created = await service.createChallenge(
+          { isMachine: true, sub: "sub-billing-lock-create", userId: "testuser" },
+          challengeData,
+          config.M2M_FULL_ACCESS_TOKEN,
+        );
+        createdChallengeId = created.id;
+        should.equal(billingLockRequests.length, 0);
+
+        const draft = await service.updateChallenge(
+          { isMachine: true, sub: "sub-billing-lock-update", userId: 22838965 },
+          created.id,
+          {
+            status: ChallengeStatusEnum.DRAFT,
+          },
+        );
+
+        should.equal(draft.billing.billingAccountId, "80001012");
+        should.equal(billingLockRequests.length, 1);
+        billingLockRequests[0].should.deep.equal({
+          billingAccountId: "80001012",
+          challengeId: created.id,
+          markup: 0.1,
+          memberPaymentAmount: 1150,
+        });
+
+        const updatedPrizeSets = _.cloneDeep(draft.prizeSets);
+        const copilotPrizeSet = _.find(
+          updatedPrizeSets,
+          (prizeSet) => _.toString(prizeSet.type).toUpperCase() === PrizeSetTypeEnum.COPILOT,
+        );
+        should.exist(copilotPrizeSet);
+        copilotPrizeSet.prizes[0].value = 225;
+        billingLockRequests = [];
+
+        await service.updateChallenge(
+          { isMachine: true, sub: "sub-billing-lock-prize-update", userId: 22838965 },
+          created.id,
+          {
+            prizeSets: updatedPrizeSets,
+          },
+        );
+
+        should.equal(billingLockRequests.length, 1);
+        billingLockRequests[0].should.deep.equal({
+          billingAccountId: "80001012",
+          challengeId: created.id,
+          markup: 0.1,
+          memberPaymentAmount: 1225,
+        });
+      } finally {
+        projectHelper.getProject = originalGetProject;
+        projectHelper.getProjectBillingInformation = originalGetProjectBillingInformation;
+
+        if (createdChallengeId) {
+          await prisma.challenge.deleteMany({ where: { id: createdChallengeId } });
+        }
+      }
+    }).timeout(10000);
 
     it("preserves existing terms when update payload omits the terms field", async () => {
       const challengeData = _.cloneDeep(testChallengeData);

--- a/test/unit/project-helper.test.js
+++ b/test/unit/project-helper.test.js
@@ -8,15 +8,18 @@ chai.should()
 
 describe('project helper unit tests', () => {
   let originalAxiosGet
+  let originalAxiosPatch
   let originalGetM2MToken
 
   beforeEach(() => {
     originalAxiosGet = axios.get
+    originalAxiosPatch = axios.patch
     originalGetM2MToken = m2mHelper.getM2MToken
   })
 
   afterEach(() => {
     axios.get = originalAxiosGet
+    axios.patch = originalAxiosPatch
     m2mHelper.getM2MToken = originalGetM2MToken
   })
 
@@ -53,6 +56,46 @@ describe('project helper unit tests', () => {
     result.should.deep.equal({
       billingAccountId: '80004217',
       markup: 0.58
+    })
+  })
+
+  it('locks challenge billing account budget with markup applied', async () => {
+    let patchUrl
+    let patchBody
+    let patchHeaders
+
+    m2mHelper.getM2MToken = async () => 'test-token'
+    axios.patch = async (url, body, options) => {
+      patchUrl = url
+      patchBody = body
+      patchHeaders = options.headers
+
+      return {
+        data: {
+          externalId: body.externalId,
+          amount: body.amount
+        }
+      }
+    }
+
+    const result = await projectHelper.lockChallengeBillingAccountAmount({
+      billingAccountId: '80001012',
+      challengeId: 'challenge-id',
+      memberPaymentAmount: 1000,
+      markup: 0.1
+    })
+
+    patchUrl.should.equal('http://localhost:4000/v6/billing-accounts/80001012/lock-amount')
+    patchBody.should.deep.equal({
+      amount: 1100,
+      challengeId: 'challenge-id',
+      externalId: 'challenge-id',
+      externalType: 'CHALLENGE'
+    })
+    patchHeaders.should.deep.equal({ Authorization: 'Bearer test-token' })
+    result.should.deep.equal({
+      externalId: 'challenge-id',
+      amount: 1100
     })
   })
 })


### PR DESCRIPTION
What was broken
Draft challenge saves persisted the challenge and its billing metadata, but they did not write a locked billing-account budget row. The Billing Account Details modal only reads locked and consumed budget rows, so newly saved draft challenge payments were missing from the list.

Root cause (if identifiable)
The previous PM-4951 fix handled finance-created winning/payment rows in tc-finance-api. QA reproduced the draft challenge editor flow, which saves challenge prize data through challenge-api-v6 and does not create a finance payment row at that point.

What was changed
challenge-api-v6 now synchronizes a billing-account lock after challenge create/update when the saved challenge is Draft, Approved, or Active. The lock amount uses the persisted member-payment total plus the challenge billing markup and writes a CHALLENGE lock row keyed by the challenge id. Finance can still replace that locked row with the finalized consumed amount when payment generation runs after completion or cancellation.

Any added/updated tests
Added project-helper coverage for the billing-account lock request and ChallengeService coverage that a saved Draft challenge triggers the billing lock sync with the expected billing account, challenge id, markup, and member-payment amount.

Validation
- pnpm exec mocha test/unit/project-helper.test.js --exit: passed.
- pnpm test: blocked because DATABASE_URL is not set for Prisma test setup and Docker is not installed in this environment to start the local Postgres service.
- pnpm lint: passed.
- pnpm build: blocked because this package does not define a build script.
- node --check on changed source/test files: passed.
