### PR TITLE
PM-4951: Include review costs in draft billing locks

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -51,6 +51,7 @@ const CHALLENGE_BILLING_LOCK_STATUSES = new Set([
   ChallengeStatusEnum.APPROVED,
   ChallengeStatusEnum.ACTIVE,
 ]);
+const DEFAULT_ESTIMATED_SUBMISSIONS_COUNT = 2;
 
 // Provide aliases for friendlier sortBy query params
 const sortByAliases = {
@@ -158,16 +159,92 @@ function getChallengePrizeSetMemberPaymentAmount(challenge) {
 }
 
 /**
+ * Reads the first-place placement prize used by reviewer cost estimates.
+ *
+ * @param {object} challenge Challenge model or response object.
+ * @returns {number|undefined} First-place USD placement prize amount, or undefined when unavailable.
+ */
+function getFirstPlacePrizeValue(challenge) {
+  const prizeSets = _.get(challenge, "prizeSets");
+
+  if (!Array.isArray(prizeSets)) {
+    return undefined;
+  }
+
+  const placementPrizeSet = _.find(
+    prizeSets,
+    (prizeSet) => _.toString(_.get(prizeSet, "type")).toUpperCase() === PrizeSetTypeEnum.PLACEMENT,
+  );
+  const firstPrize = _.get(placementPrizeSet, "prizes[0]");
+
+  if (_.toString(_.get(firstPrize, "type")).toUpperCase() !== constants.prizeTypes.USD) {
+    return undefined;
+  }
+
+  const prizeValue = _.toNumber(_.get(firstPrize, "value"));
+
+  return Number.isFinite(prizeValue) ? prizeValue : undefined;
+}
+
+/**
+ * Calculates the estimated member-review payment amount for billing locks.
+ *
+ * The work app shows review cost using a two-submission estimate, so draft
+ * budget locks need the same fixed and coefficient-based reviewer math.
+ *
+ * @param {object} challenge Challenge model or response object.
+ * @returns {number} Estimated member-review payment amount before markup.
+ */
+function getEstimatedReviewerPaymentAmount(challenge) {
+  const reviewers = _.get(challenge, "reviewers");
+
+  if (!Array.isArray(reviewers)) {
+    return 0;
+  }
+
+  const firstPlacePrizeValue = getFirstPlacePrizeValue(challenge);
+
+  if (_.isNil(firstPlacePrizeValue)) {
+    return 0;
+  }
+
+  return reviewers.reduce((total, reviewer) => {
+    if (_.get(reviewer, "isMemberReview") === false) {
+      return total;
+    }
+
+    const fixedAmount = _.toNumber(_.get(reviewer, "fixedAmount"));
+    const baseCoefficient = _.toNumber(_.get(reviewer, "baseCoefficient"));
+    const incrementalCoefficient = _.toNumber(_.get(reviewer, "incrementalCoefficient"));
+    const memberReviewerCount = Math.max(
+      1,
+      Math.trunc(_.toNumber(_.get(reviewer, "memberReviewerCount")) || 1),
+    );
+    const reviewerPayment =
+      (Number.isFinite(fixedAmount) ? fixedAmount : 0) +
+      ((Number.isFinite(baseCoefficient) ? baseCoefficient : 0) +
+        (Number.isFinite(incrementalCoefficient) ? incrementalCoefficient : 0) *
+          DEFAULT_ESTIMATED_SUBMISSIONS_COUNT) *
+        firstPlacePrizeValue;
+
+    return total + reviewerPayment * memberReviewerCount;
+  }, 0);
+}
+
+/**
  * Reads the currently persisted challenge member-payment total.
  *
  * @param {object} challenge Challenge model or response object.
- * @returns {number|undefined} Total USD member-payment amount before markup.
+ * @returns {number|undefined} Total USD member-payment amount before markup,
+ * including estimated member-review cost when prize sets are loaded.
  */
 function getChallengeMemberPaymentAmount(challenge) {
   const prizeSetMemberPaymentAmount = getChallengePrizeSetMemberPaymentAmount(challenge);
 
   if (!_.isNil(prizeSetMemberPaymentAmount)) {
-    return prizeSetMemberPaymentAmount;
+    return Number(
+      (prizeSetMemberPaymentAmount + getEstimatedReviewerPaymentAmount(challenge)).toFixed(2),
+    );
   }
 
   const totalPrizes = _.get(

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -261,9 +261,46 @@ describe("challenge service unit tests", () => {
     it("locks draft challenge budget when the challenge is saved", async () => {
       const challengeData = _.cloneDeep(testChallengeData);
       challengeData.status = ChallengeStatusEnum.DRAFT;
-      challengeData.prizeSets[0].type = PrizeSetTypeEnum.PLACEMENT;
-      challengeData.prizeSets[0].prizes[0].type = constants.prizeTypes.USD;
-      challengeData.prizeSets[0].prizes[0].value = 1000;
+      challengeData.prizeSets = [
+        {
+          type: PrizeSetTypeEnum.PLACEMENT,
+          description: "placement prizes",
+          prizes: [
+            {
+              description: "placement 1",
+              type: constants.prizeTypes.USD,
+              value: 35,
+            },
+            {
+              description: "placement 2",
+              type: constants.prizeTypes.USD,
+              value: 12,
+            },
+          ],
+        },
+        {
+          type: PrizeSetTypeEnum.COPILOT,
+          description: "copilot payment",
+          prizes: [
+            {
+              description: "copilot",
+              type: constants.prizeTypes.USD,
+              value: 10,
+            },
+          ],
+        },
+      ];
+      challengeData.reviewers = [
+        {
+          scorecardId: "scorecard-id",
+          isMemberReview: true,
+          memberReviewerCount: 1,
+          phaseId: data.phase.id,
+          fixedAmount: 16.1,
+          baseCoefficient: 0,
+          incrementalCoefficient: 0,
+        },
+      ];
       const originalGetProjectBillingInformation = projectHelper.getProjectBillingInformation;
 
       projectHelper.getProjectBillingInformation = async () => ({
@@ -284,7 +321,7 @@ describe("challenge service unit tests", () => {
           billingAccountId: "80001012",
           challengeId: result.id,
           markup: 0.1,
-          memberPaymentAmount: 1000,
+          memberPaymentAmount: 73.1,
         });
       } finally {
         projectHelper.getProjectBillingInformation = originalGetProjectBillingInformation;


### PR DESCRIPTION
What was broken
Draft challenge billing locks were using the saved prize-set total but did not include estimated member-review payments. The Billing Account Details modal therefore showed a locked draft row, but its member payment amount was lower than the challenge editor's estimated challenge total breakdown.

Root cause (if identifiable)
The previous follow-up fixed the missing locked row and included copilot prizes, but challenge-api-v6 did not apply the same review-cost calculation that the Work challenge editor uses for draft billing estimates.

What was changed
The challenge billing-lock amount now adds estimated member-review cost for USD placement challenges, using the existing two-submission estimate and reviewer fixed/coefficient fields before applying billing markup. Point-based challenges continue to skip review-cost billing estimates.

Any added/updated tests
Updated the draft challenge billing-lock unit coverage to use the QA sample shape: placement prizes, copilot fee, and review cost now produce a member-payment lock amount of 73.10 before markup.

Validation
- pnpm exec mocha test/unit/project-helper.test.js --exit: passed.
- pnpm exec mocha test/unit/ChallengeService.test.js --grep "locks draft challenge budget" --exit: blocked because DATABASE_URL is not set for Prisma test setup.
- pnpm test: blocked because DATABASE_URL is not set for Prisma test setup.
- pnpm lint: passed.
- pnpm build: blocked because this package does not define a build script.
- node --check src/services/ChallengeService.js and test/unit/ChallengeService.test.js: passed.
- pnpm exec prettier --check src/services/ChallengeService.js test/unit/ChallengeService.test.js: passed.
