### PR TITLE
PM-5021: Replace challenge skills on update

### DIFF
--- a/src/common/challenge-helper.js
+++ b/src/common/challenge-helper.js
@@ -132,11 +132,13 @@ class ChallengeHelper {
 
   /**
    * Validate Challenge skills.
-   * @param {Object} challenge the challenge
-   * @param {oldChallenge} challenge the old challenge data
+   * @param {Object} challenge the challenge payload. When skills are omitted they are left
+   * unchanged.
+   * @param {Object} oldChallenge the old challenge data used to block skill edits on completed
+   * challenges
    */
   async validateSkills(challenge, oldChallenge) {
-    if (!challenge.skills || _.isEmpty(challenge.skills)) {
+    if (!challenge.skills) {
       return;
     }
 

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -3918,9 +3918,9 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
     if (shouldReplaceTerms) {
       await tx.challengeTerm.deleteMany({ where: { challengeId } });
     }
-    // if (_.isNil(updateData.skills)) {
-    //   await tx.challengeSkill.deleteMany({ where: { challengeId } });
-    // }
+    if (!_.isNil(updateData.skills)) {
+      await tx.challengeSkill.deleteMany({ where: { challengeId } });
+    }
 
     return await tx.challenge.update({
       data: updateData,

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -1906,6 +1906,71 @@ describe("challenge service unit tests", () => {
       }
     }).timeout(5000);
 
+    it("replaces existing skills when update payload includes skills", async () => {
+      const challengeData = _.cloneDeep(testChallengeData);
+      challengeData.name = `${challengeData.name} Skills ${Date.now()}`;
+      challengeData.legacyId = Math.floor(Math.random() * 1000000);
+      const originalGetStandSkills = helper.getStandSkills;
+      const skillId1 = uuid();
+      const skillId2 = uuid();
+      let challengeWithSkills;
+
+      helper.getStandSkills = async (ids) =>
+        ids.map((skillId) => ({
+          id: skillId,
+          name: `Skill ${skillId}`,
+        }));
+
+      try {
+        challengeWithSkills = await service.createChallenge(
+          { isMachine: true, sub: "sub-skills-create", userId: 22838965 },
+          challengeData,
+          config.M2M_FULL_ACCESS_TOKEN,
+        );
+
+        await prisma.challengeSkill.createMany({
+          data: [
+            {
+              challengeId: challengeWithSkills.id,
+              skillId: skillId1,
+              createdBy: "unit-test",
+              updatedBy: "unit-test",
+            },
+            {
+              challengeId: challengeWithSkills.id,
+              skillId: skillId2,
+              createdBy: "unit-test",
+              updatedBy: "unit-test",
+            },
+          ],
+        });
+
+        const updated = await service.updateChallenge(
+          { isMachine: true, sub: "sub-skills-update", userId: 22838965 },
+          challengeWithSkills.id,
+          {
+            skills: [{ id: skillId2 }],
+          },
+        );
+
+        should.exist(updated.skills);
+        should.equal(updated.skills.length, 1);
+        should.equal(updated.skills[0].id, skillId2);
+        should.equal(updated.skills[0].name, `Skill ${skillId2}`);
+
+        const persistedSkills = await prisma.challengeSkill.findMany({
+          where: { challengeId: challengeWithSkills.id },
+        });
+        should.equal(persistedSkills.length, 1);
+        should.equal(persistedSkills[0].skillId, skillId2);
+      } finally {
+        helper.getStandSkills = originalGetStandSkills;
+        if (challengeWithSkills && challengeWithSkills.id) {
+          await prisma.challenge.delete({ where: { id: challengeWithSkills.id } });
+        }
+      }
+    }).timeout(5000);
+
     it("update challenge successfully with winners", async () => {
       const result = await service.updateChallenge(
         { isMachine: true, sub: "sub3", userId: 22838965 },


### PR DESCRIPTION
What was broken
Draft challenge updates that removed skill chips left the old ChallengeSkill rows in place, so saved drafts still showed removed skills.

Root cause
The update path converted incoming skills to nested Prisma creates but never deleted existing ChallengeSkill records before creating the replacement set. Empty skill arrays also skipped skill validation, which could bypass the completed-challenge guard once replacement works.

What was changed
When an update payload includes skills, the API deletes existing ChallengeSkill rows in the same transaction before creating the submitted rows. Skill validation now treats an empty submitted array as an explicit update while still preserving skills when the field is omitted.

Any added/updated tests
Added unit coverage for replacing persisted challenge skills with a smaller submitted set.

Validation: npm run lint passed. npm test and the focused skill-replacement test are blocked locally because PostgreSQL is not running at localhost:5432, and npm run services:up cannot start it because docker-compose is not installed. npm run build cannot run because this package does not define a build script.
