### PR TITLE
PM-5065 - allow projectIds[] param for fetching challenges

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -189,6 +189,15 @@ paths:
           required: false
           type: integer
           minimum: 1
+        - name: projectIds
+          in: query
+          description: Filter by multiple v5 project ids (array). Use repeated query params, e.g. projectIds[]=1&projectIds[]=2.
+          required: false
+          type: array
+          items:
+            type: integer
+            minimum: 1
+          collectionFormat: brackets
         - name: forumId
           in: query
           description: Filter by forum id, exact match.

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -1403,6 +1403,13 @@ async function searchChallenges(currentUser, criteria) {
     }
   });
 
+  // handle projectIds (array of project IDs, applied as IN filter)
+  if (Array.isArray(criteria.projectIds) && criteria.projectIds.length > 0) {
+    prismaFilter.where.AND.push({
+      projectId: { in: criteria.projectIds },
+    });
+  }
+
   // handle status
   if (!_.isNil(criteria.status)) {
     prismaFilter.where.AND.push({
@@ -1708,6 +1715,18 @@ async function searchChallenges(currentUser, criteria) {
       criteria.projectId,
       currentUser,
     );
+  }
+  // When filtering by multiple project IDs, treat as having project manager access
+  // (the caller is expected to pass only project IDs the user has access to)
+  if (
+    !hasProjectManagerAccessForSearch &&
+    currentUser &&
+    !_hasAdminRole &&
+    !_isMachineToken &&
+    Array.isArray(criteria.projectIds) &&
+    criteria.projectIds.length > 0
+  ) {
+    hasProjectManagerAccessForSearch = true;
   }
 
   let groupsToFilter = [];
@@ -2131,6 +2150,7 @@ searchChallenges.schema = {
       tags: Joi.array().items(Joi.string()),
       includeAllTags: Joi.boolean().default(true),
       projectId: Joi.number().integer().positive(),
+      projectIds: Joi.array().items(Joi.number().integer().positive()),
       forumId: Joi.number().integer(),
       legacyId: Joi.number().integer().positive(),
       status: Joi.string()


### PR DESCRIPTION
This pull request adds support for filtering challenges by multiple project IDs in the API and updates the access control logic to treat such queries as having project manager access (with the expectation that only accessible project IDs are provided). The changes update the API documentation, validation schema, query filtering logic, and authorization handling.

**API and Filtering Enhancements:**

* Added a new `projectIds` query parameter to the API, allowing clients to filter challenges by multiple project IDs. The parameter is documented as an array using repeated query params (e.g., `projectIds[]=1&projectIds[]=2`) in `docs/swagger.yaml`.
* Updated the validation schema in `searchChallenges.schema` to accept an array of positive integers for the new `projectIds` filter.
* Enhanced the challenge search logic in `ChallengeService.js` to apply an `IN` filter when `projectIds` is specified, enabling efficient filtering by multiple projects.

**Authorization Logic:**

* Modified the access control logic to treat searches with multiple `projectIds` as having project manager access, under the assumption that the caller only passes project IDs they are authorized to access.