### PR TITLE
PM-5065 - undo access control update

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -1716,18 +1716,6 @@ async function searchChallenges(currentUser, criteria) {
       currentUser,
     );
   }
-  // When filtering by multiple project IDs, treat as having project manager access
-  // (the caller is expected to pass only project IDs the user has access to)
-  if (
-    !hasProjectManagerAccessForSearch &&
-    currentUser &&
-    !_hasAdminRole &&
-    !_isMachineToken &&
-    Array.isArray(criteria.projectIds) &&
-    criteria.projectIds.length > 0
-  ) {
-    hasProjectManagerAccessForSearch = true;
-  }
 
   let groupsToFilter = [];
   let accessibleGroups = [];


### PR DESCRIPTION
This pull request makes a small change to the `searchChallenges` function in `ChallengeService.js`. It removes the logic that automatically grants project manager access when filtering by multiple project IDs. This means that project manager access will no longer be assumed based solely on the presence of multiple project IDs in the search criteria.