### PR TITLE
PM-5138: Sync standard submission phase dates

### DIFF
--- a/src/common/challenge-helper.js
+++ b/src/common/challenge-helper.js
@@ -806,9 +806,9 @@ class ChallengeHelper {
   enrichChallengeForResponse(challenge, track, type, options = {}) {
     if (challenge.phases && challenge.phases.length > 0) {
       const registrationPhase = _.find(challenge.phases, (p) => p.name === "Registration");
-      const submissionPhase =
-        _.find(challenge.phases, (p) => p.name === SUBMISSION_PHASE_PRIORITY[0]) ||
-        _.find(challenge.phases, (p) => p.name === SUBMISSION_PHASE_PRIORITY[1]);
+      const submissionPhase = _.find(challenge.phases, (p) =>
+        _.includes(SUBMISSION_PHASE_PRIORITY, p.name)
+      );
 
       // select last started open phase as current phase
       _.forEach(challenge.phases, (p) => {

--- a/src/common/prisma-helper.js
+++ b/src/common/prisma-helper.js
@@ -31,9 +31,7 @@ function convertChallengePhaseSchema(challenge, result, auditFields) {
   result.currentPhaseNames = _.map(_.filter(phases, (p) => p.isOpen === true), "name");
 
   const registrationPhase = _.find(phases, (p) => p.name === "Registration");
-  const submissionPhase =
-    _.find(phases, (p) => p.name === SUBMISSION_PHASE_PRIORITY[0]) ||
-    _.find(phases, (p) => p.name === SUBMISSION_PHASE_PRIORITY[1]);
+  const submissionPhase = _.find(phases, (p) => _.includes(SUBMISSION_PHASE_PRIORITY, p.name));
 
   if (registrationPhase) {
     result.registrationStartDate =

--- a/test/unit/challenge-helper.test.js
+++ b/test/unit/challenge-helper.test.js
@@ -1,0 +1,33 @@
+const chai = require('chai')
+
+const challengeHelper = require('../../src/common/challenge-helper')
+
+chai.should()
+
+describe('challenge response helper', () => {
+  it('enriches submission dates from the standard Submission phase', () => {
+    const submissionStartDate = '2026-05-22T08:00:00.000Z'
+    const submissionEndDate = '2026-05-27T08:00:00.000Z'
+    const challenge = {
+      phases: [
+        {
+          name: 'Registration',
+          phaseId: 'registration-phase',
+          scheduledEndDate: '2026-05-27T08:00:00.000Z',
+          scheduledStartDate: '2026-05-22T08:00:00.000Z'
+        },
+        {
+          name: 'Submission',
+          phaseId: 'submission-phase',
+          scheduledEndDate: submissionEndDate,
+          scheduledStartDate: submissionStartDate
+        }
+      ]
+    }
+
+    challengeHelper.enrichChallengeForResponse(challenge)
+
+    challenge.submissionStartDate.should.equal(submissionStartDate)
+    challenge.submissionEndDate.should.equal(submissionEndDate)
+  })
+})

--- a/test/unit/prisma-helper.test.js
+++ b/test/unit/prisma-helper.test.js
@@ -1,0 +1,40 @@
+const chai = require('chai')
+
+const prismaHelper = require('../../src/common/prisma-helper')
+
+chai.should()
+
+describe('prisma helper unit tests', () => {
+  it('derives submission dates from the standard Submission phase', () => {
+    const result = {}
+    const submissionStartDate = '2026-05-22T08:00:00.000Z'
+    const submissionEndDate = '2026-05-27T08:00:00.000Z'
+
+    prismaHelper.convertChallengePhaseSchema(
+      {
+        phases: [
+          {
+            name: 'Registration',
+            phaseId: 'registration-phase',
+            scheduledEndDate: '2026-05-27T08:00:00.000Z',
+            scheduledStartDate: '2026-05-22T08:00:00.000Z'
+          },
+          {
+            name: 'Submission',
+            phaseId: 'submission-phase',
+            scheduledEndDate: submissionEndDate,
+            scheduledStartDate: submissionStartDate
+          }
+        ]
+      },
+      result,
+      {
+        createdBy: 'test-user',
+        updatedBy: 'test-user'
+      }
+    )
+
+    result.submissionStartDate.should.equal(submissionStartDate)
+    result.submissionEndDate.should.equal(submissionEndDate)
+  })
+})


### PR DESCRIPTION
What was broken
Development challenges that use the standard Submission phase did not update the derived submission start/end date fields when phase schedules changed.

Root cause (if identifiable)
The API already had Submission in the priority list, but the response enrichment and Prisma update conversion only checked the first two priority entries: Topgear Submission and Topcoder Submission.

What was changed
Updated both challenge response enrichment and Prisma phase conversion to select any phase in the submission priority list, including standard Submission.

Any added/updated tests
Added unit tests for response enrichment and Prisma phase conversion with a standard Submission phase.

Focused tests pass. Full unit test execution was attempted; the suite still fails in existing unrelated DB/mock setup and validation expectation tests. The required pnpm build command is not defined in package.json.
