### PR TITLE
PM-4831: Count latest member submissions

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -63,6 +63,7 @@ const CHALLENGE_APPROVAL_ACTION_STATUSES = new Set([
 ]);
 
 const DEFAULT_ESTIMATED_SUBMISSIONS_COUNT = 2;
+const CHECKPOINT_SUBMISSION_TYPE = "CHECKPOINT_SUBMISSION";
 
 // Provide aliases for friendlier sortBy query params
 const sortByAliases = {
@@ -94,6 +95,96 @@ const CANCELLED_CHALLENGE_STATUSES = new Set([
  */
 function isCancelledChallengeStatus(status) {
   return CANCELLED_CHALLENGE_STATUSES.has(status);
+}
+
+/**
+ * Loads submission counters for challenge responses from the review submission table.
+ *
+ * Community app badges show the number of members with submissions, not the
+ * number of attempts, so repeated uploads by the same member are counted once.
+ *
+ * @param {Array<String>} challengeIds challenge identifiers to count submissions for
+ * @returns {Promise<Map<String, { numOfSubmissions: Number, numOfCheckpointSubmissions: Number }>>}
+ * counts keyed by challenge id
+ * @throws {Error} when the review database query fails
+ */
+async function getLatestSubmissionCountsByChallenge(challengeIds) {
+  const ids = _.uniq(
+    (challengeIds || [])
+      .map((challengeId) => _.toString(challengeId).trim())
+      .filter((challengeId) => !!challengeId),
+  );
+  const countsByChallenge = new Map();
+
+  if (!ids.length || !config.REVIEW_DB_URL) {
+    return countsByChallenge;
+  }
+
+  const reviewSchema = _.toString(config.REVIEW_DB_SCHEMA || "").trim();
+  const submissionTable = reviewSchema
+    ? Prisma.raw(`"${reviewSchema.replace(/"/g, '""')}"."submission"`)
+    : Prisma.raw('"submission"');
+  const reviewClient = getReviewClient();
+
+  const rows = await reviewClient.$queryRaw`
+    SELECT
+      "challengeId",
+      COUNT(DISTINCT CASE
+        WHEN "type"::text = ${CHECKPOINT_SUBMISSION_TYPE} THEN "memberId"
+      END)::int AS "numOfCheckpointSubmissions",
+      COUNT(DISTINCT CASE
+        WHEN "type"::text <> ${CHECKPOINT_SUBMISSION_TYPE} THEN "memberId"
+      END)::int AS "numOfSubmissions"
+    FROM ${submissionTable}
+    WHERE "challengeId" IN (${Prisma.join(ids)})
+      AND "memberId" IS NOT NULL
+    GROUP BY "challengeId"
+  `;
+
+  rows.forEach((row) => {
+    countsByChallenge.set(_.toString(row.challengeId), {
+      numOfSubmissions: Number(row.numOfSubmissions || 0),
+      numOfCheckpointSubmissions: Number(row.numOfCheckpointSubmissions || 0),
+    });
+  });
+
+  return countsByChallenge;
+}
+
+/**
+ * Applies latest-member submission counts to challenge records before response conversion.
+ *
+ * If the review query succeeds, challenges without submission rows are reset to
+ * zero so stale stored counters are not shown. If the query cannot run, callers
+ * keep the stored counters and log a warning instead of failing challenge reads.
+ *
+ * @param {Array<Object>} challenges challenge records being returned by the API
+ * @returns {Promise<void>}
+ */
+async function applyLatestSubmissionCounts(challenges) {
+  const records = (challenges || []).filter((challenge) => challenge && challenge.id);
+  if (!records.length || !config.REVIEW_DB_URL) {
+    return;
+  }
+
+  let countsByChallenge;
+  try {
+    countsByChallenge = await getLatestSubmissionCountsByChallenge(
+      records.map((challenge) => challenge.id),
+    );
+  } catch (err) {
+    logger.warn(`Failed to load latest submission counts: ${err.message}`);
+    return;
+  }
+
+  records.forEach((challenge) => {
+    const counts = countsByChallenge.get(_.toString(challenge.id)) || {
+      numOfSubmissions: 0,
+      numOfCheckpointSubmissions: 0,
+    };
+    challenge.numOfSubmissions = counts.numOfSubmissions;
+    challenge.numOfCheckpointSubmissions = counts.numOfCheckpointSubmissions;
+  });
 }
 
 function normalizeStatusSortValue(statusValue) {
@@ -1977,6 +2068,8 @@ async function searchChallenges(currentUser, criteria) {
       });
     }
 
+    await applyLatestSubmissionCounts(challenges);
+
     challenges.forEach((challenge) => {
       prismaHelper.convertModelToResponse(challenge);
     });
@@ -2753,6 +2846,8 @@ async function getChallenge(currentUser, id, checkIfExists) {
   if (!hasAdminRole(currentUser) && !_.get(currentUser, "isMachine", false)) {
     _.unset(challenge, "payments");
   }
+
+  await applyLatestSubmissionCounts([challenge]);
 
   prismaHelper.convertModelToResponse(challenge);
 
@@ -5297,6 +5392,8 @@ module.exports = {
     shouldSkipChallengeApprovalFlow,
     syncChallengeBillingAccountLock,
     validateChallengeActivationBillingAccount,
+    getLatestSubmissionCountsByChallenge,
+    applyLatestSubmissionCounts,
   },
   searchChallenges,
   createChallenge,

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -24,6 +24,7 @@ const { getReviewClient } = require("../../src/common/review-prisma");
 const prisma = getClient();
 const reviewSchema = config.get("REVIEW_DB_SCHEMA");
 const reviewTableName = `"${reviewSchema}"."review"`;
+const submissionTableName = `"${reviewSchema}"."submission"`;
 const should = chai.should();
 let reviewClient;
 
@@ -78,6 +79,31 @@ describe("challenge service unit tests", () => {
       ADD COLUMN IF NOT EXISTS "scorecardId" varchar(255)
     `);
     await reviewClient.$executeRawUnsafe(`DELETE FROM ${reviewTableName}`);
+    await reviewClient.$executeRawUnsafe(`
+      CREATE TABLE IF NOT EXISTS ${submissionTableName} (
+        "id" varchar(64) PRIMARY KEY,
+        "challengeId" varchar(255),
+        "memberId" varchar(255),
+        "type" varchar(64),
+        "status" varchar(64),
+        "submittedDate" timestamp,
+        "createdAt" timestamp DEFAULT now(),
+        "updatedAt" timestamp DEFAULT now()
+      )
+    `);
+    await reviewClient.$executeRawUnsafe(`
+      ALTER TABLE ${submissionTableName}
+      ADD COLUMN IF NOT EXISTS "challengeId" varchar(255)
+    `);
+    await reviewClient.$executeRawUnsafe(`
+      ALTER TABLE ${submissionTableName}
+      ADD COLUMN IF NOT EXISTS "memberId" varchar(255)
+    `);
+    await reviewClient.$executeRawUnsafe(`
+      ALTER TABLE ${submissionTableName}
+      ADD COLUMN IF NOT EXISTS "type" varchar(64)
+    `);
+    await reviewClient.$executeRawUnsafe(`DELETE FROM ${submissionTableName}`);
 
     testChallengeData = {
       typeId: data.challenge.typeId,
@@ -620,6 +646,58 @@ describe("challenge service unit tests", () => {
       should.exist(result.created);
       should.equal(result.numOfSubmissions, 0);
       should.equal(result.numOfRegistrants, 0);
+    });
+
+    it("returns latest-member submission counters for challenge detail and listing", async () => {
+      const challengeId = data.challenge.id;
+      await prisma.challenge.update({
+        where: { id: challengeId },
+        data: {
+          numOfSubmissions: 5,
+          numOfCheckpointSubmissions: 2,
+        },
+      });
+
+      await reviewClient.$executeRawUnsafe(`
+        INSERT INTO ${submissionTableName}
+          ("id", "challengeId", "memberId", "type", "status", "submittedDate")
+        VALUES
+          ('pm4831a1', '${challengeId}', 'member-1', 'CONTEST_SUBMISSION', 'ACTIVE', '2026-01-01T00:00:00Z'),
+          ('pm4831a2', '${challengeId}', 'member-1', 'CONTEST_SUBMISSION', 'ACTIVE', '2026-01-02T00:00:00Z'),
+          ('pm4831b1', '${challengeId}', 'member-2', 'CONTEST_SUBMISSION', 'ACTIVE', '2026-01-03T00:00:00Z'),
+          ('pm4831c1', '${challengeId}', 'member-3', 'CONTEST_SUBMISSION', 'ACTIVE', '2026-01-04T00:00:00Z'),
+          ('pm4831d1', '${challengeId}', 'member-4', 'CHECKPOINT_SUBMISSION', 'ACTIVE', '2026-01-05T00:00:00Z'),
+          ('pm4831d2', '${challengeId}', 'member-4', 'CHECKPOINT_SUBMISSION', 'ACTIVE', '2026-01-06T00:00:00Z')
+      `);
+
+      try {
+        const detail = await service.getChallenge({ isMachine: true }, challengeId);
+        should.equal(detail.numOfSubmissions, 3);
+        should.equal(detail.numOfCheckpointSubmissions, 1);
+
+        const listing = await service.searchChallenges(
+          { isMachine: true },
+          {
+            id: challengeId,
+            page: 1,
+            perPage: 10,
+          },
+        );
+        should.equal(listing.result.length, 1);
+        should.equal(listing.result[0].numOfSubmissions, 3);
+        should.equal(listing.result[0].numOfCheckpointSubmissions, 1);
+      } finally {
+        await reviewClient.$executeRawUnsafe(
+          `DELETE FROM ${submissionTableName} WHERE "challengeId" = '${challengeId}'`,
+        );
+        await prisma.challenge.update({
+          where: { id: challengeId },
+          data: {
+            numOfSubmissions: 0,
+            numOfCheckpointSubmissions: 0,
+          },
+        });
+      }
     });
 
     it("get challenge preserves billing for project write users", async () => {


### PR DESCRIPTION
What was broken
Challenge listing and detail responses used stored submission counters that represented every submission attempt. Members with multiple attempts inflated the Community app submission badge.

Root cause
The challenge response relied on Challenge.numOfSubmissions and Challenge.numOfCheckpointSubmissions counters instead of deriving the latest-member count from review submissions.

What was changed
Challenge search and detail responses now override submission counters from the review submission table by counting distinct submitting members per challenge and submission type. If the review count lookup is unavailable, the API keeps the stored counters so challenge reads still succeed.

Any added/updated tests
Added a ChallengeService regression test that inserts repeated contest and checkpoint submissions, then verifies both challenge detail and listing responses return latest-member counts.
