### PR TITLE
PM-5138: Preserve schedule end date updates

### DIFF
--- a/src/common/phase-helper.js
+++ b/src/common/phase-helper.js
@@ -10,6 +10,61 @@ const prisma = require("../common/prisma").getClient();
 
 const SUBMISSION_PHASE_PRIORITY = ["Topgear Submission", "Topcoder Submission", "Submission"];
 
+/**
+ * Apply an explicit scheduled end date to a phase and update its duration.
+ *
+ * @param {Object} phase challenge phase being recalculated
+ * @param {Date|String} scheduledEndDate scheduled end date supplied by the update payload
+ * @returns {Boolean} true when the scheduled end date was applied
+ * @throws {BadRequestError} when the supplied end date is invalid or not after the phase start
+ */
+function applyScheduledEndDate(phase, scheduledEndDate) {
+  if (_.isNil(scheduledEndDate)) {
+    return false;
+  }
+
+  const scheduledStart = moment(phase.scheduledStartDate);
+  const scheduledEnd = moment(scheduledEndDate);
+
+  if (!scheduledEnd.isValid()) {
+    throw new errors.BadRequestError(
+      `scheduledEndDate: ${scheduledEndDate} should be a valid date`
+    );
+  }
+
+  if (!scheduledEnd.isAfter(scheduledStart)) {
+    throw new errors.BadRequestError(
+      `scheduledEndDate: ${scheduledEndDate} should be after scheduledStartDate: ${phase.scheduledStartDate}`
+    );
+  }
+
+  phase.scheduledEndDate = scheduledEnd.toDate().toISOString();
+  phase.duration = scheduledEnd.diff(scheduledStart, "seconds");
+  return true;
+}
+
+/**
+ * Recalculate a phase's scheduled end date from either explicit input or duration.
+ *
+ * @param {Object} phase challenge phase being recalculated
+ * @returns {undefined} mutates the provided phase
+ * @throws {BadRequestError} when an explicit scheduled end date is invalid
+ */
+function recalculateScheduledEndDate(phase) {
+  if (!_.isNil(phase.actualEndDate)) {
+    return;
+  }
+
+  if (applyScheduledEndDate(phase, phase.requestedScheduledEndDate)) {
+    return;
+  }
+
+  phase.scheduledEndDate = moment(phase.scheduledStartDate)
+    .add(phase.duration, "seconds")
+    .toDate()
+    .toISOString();
+}
+
 class ChallengePhaseHelper {
   phaseDefinitionMap = {};
   timelineTemplateMap = {};
@@ -141,6 +196,7 @@ class ChallengePhaseHelper {
         ...phase,
         predecessor: resolvedPredecessor,
         description: phaseDefinition.description,
+        requestedScheduledEndDate: _.get(newPhase, "scheduledEndDate"),
       };
       if (updatedPhase.name === "Post-Mortem") {
         updatedPhase.predecessor = "a93544bc-c165-4af4-b55e-18f3593b457a";
@@ -166,10 +222,7 @@ class ChallengePhaseHelper {
         } else if (_.isNil(phase.actualStartDate)) {
           updatedPhase.scheduledStartDate = moment(scheduledStartDate).toDate().toISOString();
         }
-        updatedPhase.scheduledEndDate = moment(updatedPhase.scheduledStartDate)
-          .add(updatedPhase.duration, "seconds")
-          .toDate()
-          .toISOString();
+        recalculateScheduledEndDate(updatedPhase);
       }
       if (_.isNil(phase.actualEndDate) && !_.isNil(newPhase) && !_.isNil(newPhase.constraints)) {
         updatedPhase.constraints = newPhase.constraints;
@@ -221,14 +274,9 @@ class ChallengePhaseHelper {
       } else if (_.isNil(phase.actualStartDate)) {
         phase.scheduledStartDate = predecessorPhase.scheduledEndDate;
       }
-      if (_.isNil(phase.actualEndDate)) {
-        phase.scheduledEndDate = moment(phase.scheduledStartDate)
-          .add(phase.duration, "seconds")
-          .toDate()
-          .toISOString();
-      }
+      recalculateScheduledEndDate(phase);
     }
-    return updatedPhases;
+    return _.map(updatedPhases, (phase) => _.omit(phase, "requestedScheduledEndDate"));
   }
 
   handlePhasesAfterCancelling(phases) {

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -4347,6 +4347,7 @@ updateChallenge.schema = {
               isOpen: Joi.boolean(),
               actualEndDate: Joi.date().allow(null),
               scheduledStartDate: Joi.date().allow(null),
+              scheduledEndDate: Joi.date().allow(null),
               constraints: Joi.array()
                 .items(
                   Joi.object()
@@ -4869,7 +4870,13 @@ function sanitizeChallenge(challenge) {
   }
   if (challenge.phases) {
     sanitized.phases = _.map(challenge.phases, (phase) =>
-      _.pick(phase, ["phaseId", "duration", "scheduledStartDate", "constraints"]),
+      _.pick(phase, [
+        "phaseId",
+        "duration",
+        "scheduledStartDate",
+        "scheduledEndDate",
+        "constraints",
+      ]),
     );
   }
   if (challenge.prizeSets) {

--- a/test/unit/phase-helper.test.js
+++ b/test/unit/phase-helper.test.js
@@ -1,0 +1,166 @@
+const chai = require('chai')
+
+const phaseHelper = require('../../src/common/phase-helper')
+
+chai.should()
+
+describe('phase helper unit tests', () => {
+  const originalGetTemplateAndTemplateMap = phaseHelper.getTemplateAndTemplateMap
+  const originalGetPhaseDefinitionsAndMap = phaseHelper.getPhaseDefinitionsAndMap
+
+  afterEach(() => {
+    phaseHelper.getTemplateAndTemplateMap = originalGetTemplateAndTemplateMap
+    phaseHelper.getPhaseDefinitionsAndMap = originalGetPhaseDefinitionsAndMap
+  })
+
+  /**
+   * Install phase/template lookup stubs for schedule recalculation tests.
+   *
+   * @param {Array<Object>} phaseDefinitions phase records returned by phase lookup.
+   * @param {Array<Object>} templatePhases template phase records returned by timeline lookup.
+   * @returns {undefined} mutates the shared helper singleton for the current test.
+   */
+  function stubPhaseLookups (phaseDefinitions, templatePhases) {
+    const phaseDefinitionMap = new Map(phaseDefinitions.map((phase) => [phase.id, phase]))
+    const timelineTemplateMap = new Map(templatePhases.map((phase) => [phase.phaseId, phase]))
+
+    phaseHelper.getPhaseDefinitionsAndMap = async () => ({
+      phaseDefinitionMap,
+      phaseDefinitions
+    })
+    phaseHelper.getTemplateAndTemplateMap = async () => ({
+      timelineTemplateMap,
+      timelineTempate: templatePhases
+    })
+  }
+
+  it('uses scheduled end dates from update payload when recalculating phases', async () => {
+    const registrationPhaseId = 'registration-phase'
+    const submissionPhaseId = 'submission-phase'
+    const staleDuration = 24 * 60 * 60
+    const registrationStartDate = '2026-05-26T05:14:00.000Z'
+    const registrationEndDate = '2026-05-29T05:14:00.000Z'
+    const submissionEndDate = '2026-06-02T05:14:00.000Z'
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' },
+        { id: submissionPhaseId, name: 'Submission', description: 'Submission phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: staleDuration },
+        {
+          phaseId: submissionPhaseId,
+          predecessor: registrationPhaseId,
+          defaultDuration: staleDuration
+        }
+      ]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          duration: staleDuration,
+          name: 'Registration',
+          phaseId: registrationPhaseId,
+          scheduledStartDate: registrationStartDate,
+          scheduledEndDate: '2026-05-27T05:14:00.000Z'
+        },
+        {
+          duration: staleDuration,
+          name: 'Submission',
+          phaseId: submissionPhaseId,
+          predecessor: registrationPhaseId,
+          scheduledStartDate: '2026-05-27T05:14:00.000Z',
+          scheduledEndDate: '2026-05-28T05:14:00.000Z'
+        }
+      ],
+      [
+        {
+          duration: staleDuration,
+          phaseId: registrationPhaseId,
+          scheduledEndDate: registrationEndDate,
+          scheduledStartDate: registrationStartDate
+        },
+        {
+          duration: staleDuration,
+          phaseId: submissionPhaseId,
+          scheduledEndDate: submissionEndDate
+        }
+      ],
+      'timeline-template-id',
+      false
+    )
+
+    updatedPhases[0].scheduledEndDate.should.equal(registrationEndDate)
+    updatedPhases[0].duration.should.equal(3 * 24 * 60 * 60)
+    updatedPhases[1].scheduledStartDate.should.equal(registrationEndDate)
+    updatedPhases[1].scheduledEndDate.should.equal(submissionEndDate)
+    updatedPhases[1].duration.should.equal(4 * 24 * 60 * 60)
+  })
+
+  it('uses scheduled end dates from update payload for MM phases', async () => {
+    const registrationPhaseId = 'mm-registration-phase'
+    const submissionPhaseId = 'mm-submission-phase'
+    const staleDuration = 12 * 60 * 60
+    const registrationStartDate = '2026-06-01T00:00:00.000Z'
+    const registrationEndDate = '2026-06-03T00:00:00.000Z'
+    const submissionEndDate = '2026-06-06T00:00:00.000Z'
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'MM Registration', description: 'MM Registration phase' },
+        { id: submissionPhaseId, name: 'MM Submission', description: 'MM Submission phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: staleDuration },
+        {
+          phaseId: submissionPhaseId,
+          predecessor: registrationPhaseId,
+          defaultDuration: staleDuration
+        }
+      ]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          duration: staleDuration,
+          name: 'MM Registration',
+          phaseId: registrationPhaseId,
+          scheduledStartDate: registrationStartDate,
+          scheduledEndDate: '2026-06-01T12:00:00.000Z'
+        },
+        {
+          duration: staleDuration,
+          name: 'MM Submission',
+          phaseId: submissionPhaseId,
+          predecessor: registrationPhaseId,
+          scheduledStartDate: '2026-06-01T12:00:00.000Z',
+          scheduledEndDate: '2026-06-02T00:00:00.000Z'
+        }
+      ],
+      [
+        {
+          duration: staleDuration,
+          phaseId: registrationPhaseId,
+          scheduledEndDate: registrationEndDate,
+          scheduledStartDate: registrationStartDate
+        },
+        {
+          duration: staleDuration,
+          phaseId: submissionPhaseId,
+          scheduledEndDate: submissionEndDate
+        }
+      ],
+      'timeline-template-id',
+      false
+    )
+
+    updatedPhases[0].scheduledEndDate.should.equal(registrationEndDate)
+    updatedPhases[0].duration.should.equal(2 * 24 * 60 * 60)
+    updatedPhases[1].scheduledStartDate.should.equal(registrationEndDate)
+    updatedPhases[1].scheduledEndDate.should.equal(submissionEndDate)
+    updatedPhases[1].duration.should.equal(3 * 24 * 60 * 60)
+  })
+})


### PR DESCRIPTION
What was broken
Challenge update requests could include edited phase scheduledEndDate values, but the API dropped those fields during sanitization and recalculated phase ends from the previous duration.

Root cause (if identifiable)
The earlier PM-5138 fix updated derived submission date mapping, but the challenge update path still only allowed scheduledStartDate and duration through for phases. When Work sent an edited registration or submission end date, populatePhasesForChallengeUpdate never saw it.

What was changed
Allowed scheduledEndDate in the challenge update phase schema and sanitizer. Phase schedule recalculation now applies an explicit scheduledEndDate when provided, derives duration from the resulting start/end range, and cascades successor starts from the preserved predecessor end.

Any added/updated tests
Added phase-helper unit coverage for Development-style Registration/Submission phases and MM Registration/MM Submission phases with edited scheduled end dates.

Validation
- pnpm lint passed.
- Focused PM-5138 tests passed: pnpm test -- --grep "phase helper|prisma helper|challenge response helper".
- pnpm exec standard test/unit/phase-helper.test.js test/unit/prisma-helper.test.js test/unit/challenge-helper.test.js passed.
- pnpm build could not run because this package has no build script or build executable.
- Full pnpm test was attempted first without DATABASE_URL and failed at DB-backed setup. After starting the local PostgreSQL container and running prisma db push on a disposable local schema, the suite progressed but still failed in existing unrelated validation/mock expectation tests.
