### PR TITLE
PM-5161: Guard MM winner selection until final scoring completes

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -187,6 +187,173 @@ async function applyLatestSubmissionCounts(challenges) {
   });
 }
 
+/**
+ * Loads the latest non-checkpoint Marathon Match submission per member from
+ * the review database.
+ *
+ * The close flow uses this to avoid selecting winners before parallel system
+ * scoring has produced a final summation for every member's latest attempt.
+ *
+ * @param {String} challengeId challenge identifier
+ * @returns {Promise<Array<Object>>} latest submission rows keyed by member
+ */
+async function getLatestMarathonMatchSubmissions(challengeId) {
+  if (!config.REVIEW_DB_URL) {
+    return [];
+  }
+
+  const reviewSchema = _.toString(config.REVIEW_DB_SCHEMA || "").trim();
+  const submissionTable = reviewSchema
+    ? Prisma.raw(`"${reviewSchema.replace(/"/g, '""')}"."submission"`)
+    : Prisma.raw('"submission"');
+  const reviewClient = getReviewClient();
+
+  return reviewClient.$queryRaw`
+    SELECT
+      "id",
+      "memberId",
+      "submittedDate",
+      "createdAt",
+      "updatedAt"
+    FROM (
+      SELECT
+        "id",
+        "memberId",
+        "submittedDate",
+        "createdAt",
+        "updatedAt",
+        ROW_NUMBER() OVER (
+          PARTITION BY "memberId"
+          ORDER BY
+            COALESCE("isLatest", false) DESC,
+            COALESCE("submittedDate", "createdAt", "updatedAt") DESC,
+            "id" DESC
+        ) AS "rowNumber"
+      FROM ${submissionTable}
+      WHERE "challengeId" = ${challengeId}
+        AND "memberId" IS NOT NULL
+        AND COALESCE("type"::text, '') <> ${CHECKPOINT_SUBMISSION_TYPE}
+        AND COALESCE("status"::text, '') <> 'DELETED'
+    ) ranked
+    WHERE "rowNumber" = 1
+  `;
+}
+
+/**
+ * Normalizes identifiers used to match review summations to submissions.
+ * @param {*} value raw identifier value
+ * @returns {String} trimmed identifier, or an empty string when absent
+ */
+function normalizeMatchId(value) {
+  return _.toString(value || "").trim();
+}
+
+/**
+ * Reads a review summation timestamp for latest-result comparisons.
+ * @param {Object} summation review summation returned by Review API
+ * @returns {Number} timestamp in milliseconds, or zero when unavailable
+ */
+function getReviewSummationTimestampValue(summation) {
+  const candidate =
+    _.get(summation, "reviewedDate") ||
+    _.get(summation, "updatedAt") ||
+    _.get(summation, "createdAt");
+  const timestamp = new Date(candidate).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+/**
+ * Compares two final review summations for the same submission or submitter.
+ * Newer summations win; ties keep the higher score.
+ *
+ * @param {Object|null} current currently selected summation
+ * @param {Object} candidate summation being considered
+ * @returns {Boolean} true when candidate should replace current
+ */
+function shouldReplaceSelectedFinalSummation(current, candidate) {
+  if (!current) {
+    return true;
+  }
+
+  const currentTimestamp = getReviewSummationTimestampValue(current);
+  const candidateTimestamp = getReviewSummationTimestampValue(candidate);
+  if (candidateTimestamp !== currentTimestamp) {
+    return candidateTimestamp > currentTimestamp;
+  }
+
+  return Number(candidate.aggregateScore) > Number(current.aggregateScore);
+}
+
+/**
+ * Selects the final summations that should determine Marathon Match winners.
+ *
+ * When latest submission rows are available, every latest submission must have
+ * a matching final summation. Without submission rows, the function falls back
+ * to the newest final summation per submitter to preserve legacy behavior while
+ * avoiding duplicate winner placements for repeated attempts.
+ *
+ * @param {String} challengeId challenge identifier used in error messages
+ * @param {Array<Object>} finalSummations final review summations
+ * @param {Array<Object>} latestSubmissions latest submission rows
+ * @returns {Array<Object>} selected final summations to rank
+ * @throws {BadRequestError} when any latest submission has no final summation
+ */
+function selectMarathonMatchWinnerSummations(challengeId, finalSummations, latestSubmissions) {
+  if (!Array.isArray(latestSubmissions) || latestSubmissions.length === 0) {
+    const latestBySubmitter = new Map();
+    finalSummations.forEach((summation) => {
+      const submitterId = normalizeMatchId(summation.submitterId);
+      if (!submitterId) {
+        return;
+      }
+      if (shouldReplaceSelectedFinalSummation(latestBySubmitter.get(submitterId), summation)) {
+        latestBySubmitter.set(submitterId, summation);
+      }
+    });
+    return Array.from(latestBySubmitter.values());
+  }
+
+  const finalBySubmission = new Map();
+  finalSummations.forEach((summation) => {
+    const submitterId = normalizeMatchId(summation.submitterId);
+    const submissionId = normalizeMatchId(summation.submissionId);
+    if (!submitterId || !submissionId) {
+      return;
+    }
+    const key = `${submitterId}:${submissionId}`;
+    if (shouldReplaceSelectedFinalSummation(finalBySubmission.get(key), summation)) {
+      finalBySubmission.set(key, summation);
+    }
+  });
+
+  const selectedSummations = [];
+  const missingSubmissions = [];
+  latestSubmissions.forEach((submission) => {
+    const memberId = normalizeMatchId(submission.memberId);
+    const submissionId = normalizeMatchId(submission.id);
+    if (!memberId || !submissionId) {
+      return;
+    }
+
+    const summation = finalBySubmission.get(`${memberId}:${submissionId}`);
+    if (summation) {
+      selectedSummations.push(summation);
+    } else {
+      missingSubmissions.push(submissionId);
+    }
+  });
+
+  if (missingSubmissions.length > 0) {
+    throw new errors.BadRequestError(
+      `Cannot close Marathon Match challenge ${challengeId}: final system scoring is not complete for latest submissions. Missing final summations for submissionIds: ${missingSubmissions.join(
+        ", ",
+      )}`,
+    );
+  }
+
+  return selectedSummations;
+}
+
 function normalizeStatusSortValue(statusValue) {
   if (_.isNil(statusValue)) {
     return null;
@@ -5355,9 +5522,15 @@ async function closeMarathonMatch(currentUser, challengeId) {
   const finalSummations = (reviewSummations || []).filter(
     (summation) => summation.isFinal === true,
   );
+  const latestSubmissions = await getLatestMarathonMatchSubmissions(challengeId);
+  const winnerSummations = selectMarathonMatchWinnerSummations(
+    challengeId,
+    finalSummations,
+    latestSubmissions,
+  );
 
   const orderedSummations = _.orderBy(
-    finalSummations,
+    winnerSummations,
     ["aggregateScore", "createdAt"],
     ["desc", "asc"],
   );

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -103,6 +103,10 @@ describe("challenge service unit tests", () => {
       ALTER TABLE ${submissionTableName}
       ADD COLUMN IF NOT EXISTS "type" varchar(64)
     `);
+    await reviewClient.$executeRawUnsafe(`
+      ALTER TABLE ${submissionTableName}
+      ADD COLUMN IF NOT EXISTS "isLatest" boolean
+    `);
     await reviewClient.$executeRawUnsafe(`DELETE FROM ${submissionTableName}`);
 
     testChallengeData = {
@@ -2978,6 +2982,9 @@ describe("challenge service unit tests", () => {
             updatedBy: "admin",
           },
         });
+        await reviewClient.$executeRawUnsafe(
+          `DELETE FROM ${submissionTableName} WHERE "challengeId" = '${data.marathonMatchChallenge.id}'`,
+        );
       }
     });
 
@@ -3053,6 +3060,123 @@ describe("challenge service unit tests", () => {
         should.equal(phase.isOpen, false);
         should.exist(phase.actualEndDate);
       });
+    });
+
+    it("close marathon match selects winners from latest member final summations", async () => {
+      await reviewClient.$executeRawUnsafe(`
+        INSERT INTO ${submissionTableName}
+          ("id", "challengeId", "memberId", "type", "status", "submittedDate", "createdAt", "updatedAt", "isLatest")
+        VALUES
+          ('old-topacc-submission', '${data.marathonMatchChallenge.id}', '12345678', 'Contest Submission', 'ACTIVE', '2024-05-01T09:00:00.000Z', '2024-05-01T09:00:00.000Z', '2024-05-01T09:00:00.000Z', false),
+          ('latest-topacc-submission', '${data.marathonMatchChallenge.id}', '12345678', 'Contest Submission', 'ACTIVE', '2024-05-01T10:00:00.000Z', '2024-05-01T10:00:00.000Z', '2024-05-01T10:00:00.000Z', true),
+          ('old-liuliquan-submission', '${data.marathonMatchChallenge.id}', '9876543', 'Contest Submission', 'ACTIVE', '2024-05-01T09:05:00.000Z', '2024-05-01T09:05:00.000Z', '2024-05-01T09:05:00.000Z', false),
+          ('latest-liuliquan-submission', '${data.marathonMatchChallenge.id}', '9876543', 'Contest Submission', 'ACTIVE', '2024-05-01T10:05:00.000Z', '2024-05-01T10:05:00.000Z', '2024-05-01T10:05:00.000Z', true)
+      `);
+
+      const originalGetReviewSummations = helper.getReviewSummations;
+      helper.getReviewSummations = async () => [
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: true,
+          aggregateScore: 75.8,
+          submissionId: "old-topacc-submission",
+          submitterId: "12345678",
+          submitterHandle: "thomaskranitsas",
+          createdAt: "2024-05-01T09:15:00.000Z",
+          reviewedDate: "2024-05-01T09:15:00.000Z",
+        },
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: true,
+          aggregateScore: 95.7,
+          submissionId: "latest-topacc-submission",
+          submitterId: "12345678",
+          submitterHandle: "thomaskranitsas",
+          createdAt: "2024-05-01T10:15:00.000Z",
+          reviewedDate: "2024-05-01T10:15:00.000Z",
+        },
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: true,
+          aggregateScore: 99.9,
+          submissionId: "old-liuliquan-submission",
+          submitterId: "9876543",
+          submitterHandle: "tonyj",
+          createdAt: "2024-05-01T09:20:00.000Z",
+          reviewedDate: "2024-05-01T09:20:00.000Z",
+        },
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: true,
+          aggregateScore: 83.6,
+          submissionId: "latest-liuliquan-submission",
+          submitterId: "9876543",
+          submitterHandle: "tonyj",
+          createdAt: "2024-05-01T10:20:00.000Z",
+          reviewedDate: "2024-05-01T10:20:00.000Z",
+        },
+      ];
+      originalReviewSummations = originalGetReviewSummations;
+
+      const originalGetChallengeResources = helper.getChallengeResources;
+      helper.getChallengeResources = async () => [
+        { roleId: config.SUBMITTER_ROLE_ID, memberId: 12345678, memberHandle: "thomaskranitsas" },
+        { roleId: config.SUBMITTER_ROLE_ID, memberId: 9876543, memberHandle: "tonyj" },
+      ];
+      originalChallengeResources = originalGetChallengeResources;
+
+      const result = await service.closeMarathonMatch(adminUser, data.marathonMatchChallenge.id);
+
+      should.exist(result);
+      should.equal(result.status, ChallengeStatusEnum.COMPLETED);
+      should.equal(result.winners.length, 2);
+      should.equal(result.winners[0].placement, 1);
+      should.equal(result.winners[0].userId, 12345678);
+      should.equal(result.winners[1].placement, 2);
+      should.equal(result.winners[1].userId, 9876543);
+    });
+
+    it("close marathon match blocks until all latest submissions have final summations", async () => {
+      await reviewClient.$executeRawUnsafe(`
+        INSERT INTO ${submissionTableName}
+          ("id", "challengeId", "memberId", "type", "status", "submittedDate", "createdAt", "updatedAt", "isLatest")
+        VALUES
+          ('latest-topacc-submission', '${data.marathonMatchChallenge.id}', '12345678', 'Contest Submission', 'ACTIVE', '2024-05-02T10:00:00.000Z', '2024-05-02T10:00:00.000Z', '2024-05-02T10:00:00.000Z', true),
+          ('latest-liuliquan-submission', '${data.marathonMatchChallenge.id}', '9876543', 'Contest Submission', 'ACTIVE', '2024-05-02T10:05:00.000Z', '2024-05-02T10:05:00.000Z', '2024-05-02T10:05:00.000Z', true)
+      `);
+
+      const originalGetReviewSummations = helper.getReviewSummations;
+      helper.getReviewSummations = async () => [
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: true,
+          aggregateScore: 83.6,
+          submissionId: "latest-liuliquan-submission",
+          submitterId: "9876543",
+          submitterHandle: "tonyj",
+          createdAt: "2024-05-02T10:20:00.000Z",
+          reviewedDate: "2024-05-02T10:20:00.000Z",
+        },
+      ];
+      originalReviewSummations = originalGetReviewSummations;
+
+      try {
+        await service.closeMarathonMatch(adminUser, data.marathonMatchChallenge.id);
+      } catch (e) {
+        should.equal(e.name, "BadRequestError");
+        should.equal(
+          e.message.indexOf("final system scoring is not complete for latest submissions") >= 0,
+          true,
+        );
+        should.equal(e.message.indexOf("latest-topacc-submission") >= 0, true);
+        return;
+      }
+      throw new Error("should not reach here");
     });
 
     it("close marathon match successfully with M2M token", async () => {


### PR DESCRIPTION
What was broken

Marathon Match challenge closing could persist winners before all parallel system scoring callbacks had written final summations for every member's latest submission. If an early final summation belonged to a lower-scoring member, that member could be stored as the winner even after later final scores showed a different winner.

Root cause (if identifiable)

closeMarathonMatch ranked whatever final review summations existed at the time of the close request. It did not verify that every latest member submission had a final/system summation, and it did not limit winner ranking to the latest submission for each member.

What was changed

Loaded latest non-checkpoint submissions from the review database during Marathon Match close. Winner selection now requires each latest submission to have a matching final summation before the challenge can be completed, and ranks only those latest-submission final summations. When submission rows are unavailable, the logic falls back to the newest final summation per submitter to avoid duplicate placements.

Any added/updated tests

Added ChallengeService unit coverage for ranking winners from latest member final summations and blocking close while any latest submission is missing a final summation.
