### PR TITLE
Allow opening approval phase without approval user in AI Only challenges

### DIFF
--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -541,8 +541,8 @@ async function ensureRequiredResourcesBeforeOpeningPhase(challenge, phaseName) {
     return;
   }
 
-  // For AI_ONLY review mode, no human Reviewer resources are required
-  if (normalizedPhaseName === "review") {
+  // For AI_ONLY review mode, no human Reviewer or Approver resources are required
+  if (normalizedPhaseName === "review" || normalizedPhaseName === "approval") {
     try {
       const aiReviewConfig = await helper.getAIReviewConfigByChallengeId(challenge.id);
       if (aiReviewConfig?.mode === "AI_ONLY") {

--- a/test/unit/ChallengePhaseService.test.js
+++ b/test/unit/ChallengePhaseService.test.js
@@ -1713,6 +1713,55 @@ describe('challenge phase service unit tests', () => {
       throw new Error('should not reach here')
     })
 
+    it('partially update challenge phase - opens approval phase without approver resource for AI_ONLY challenges', async () => {
+      const approvalPhase = await prisma.phase.create({
+        data: {
+          id: uuid(),
+          name: 'Approval',
+          description: 'desc',
+          isOpen: false,
+          duration: 86400,
+          createdBy: 'admin',
+          updatedBy: 'admin'
+        }
+      })
+      const approvalChallengePhaseId = uuid()
+      await prisma.challengePhase.create({
+        data: {
+          id: approvalChallengePhaseId,
+          challengeId: data.challenge.id,
+          phaseId: approvalPhase.id,
+          name: 'Approval',
+          isOpen: false,
+          createdBy: 'admin',
+          updatedBy: 'admin'
+        }
+      })
+
+      const originalGetAIReviewConfigByChallengeId = helper.getAIReviewConfigByChallengeId
+      const originalGetChallengeResources = helper.getChallengeResources
+      const originalGetResourceRoles = helper.getResourceRoles
+      helper.getAIReviewConfigByChallengeId = async () => ({ mode: 'AI_ONLY' })
+      helper.getChallengeResources = async () => []
+      helper.getResourceRoles = async () => [{ id: 'approver-role-id', name: 'Approver' }]
+
+      try {
+        const challengePhase = await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          approvalChallengePhaseId,
+          { isOpen: true }
+        )
+        should.equal(challengePhase.isOpen, true)
+      } finally {
+        helper.getAIReviewConfigByChallengeId = originalGetAIReviewConfigByChallengeId
+        helper.getChallengeResources = originalGetChallengeResources
+        helper.getResourceRoles = originalGetResourceRoles
+        await prisma.challengePhase.delete({ where: { id: approvalChallengePhaseId } })
+        await prisma.phase.delete({ where: { id: approvalPhase.id } })
+      }
+    })
+
     it('partially update challenge phase - opens marathon match review phase without reviewer resource', async () => {
       const reviewPhase = await prisma.phase.create({
         data: {


### PR DESCRIPTION
This pull request updates the logic for handling required resources when opening challenge phases, specifically for challenges in "AI_ONLY" review mode. The main change is to ensure that both the "review" and "approval" phases do not require human Reviewer or Approver resources for AI_ONLY challenges. Additionally, a new unit test is added to verify this behavior for the "approval" phase.

**Logic updates for phase resource requirements:**

* Updated `ensureRequiredResourcesBeforeOpeningPhase` in `ChallengePhaseService.js` to skip both Reviewer and Approver resource checks for "review" and "approval" phases when the challenge is in AI_ONLY mode.

**Testing improvements:**

* Added a unit test in `ChallengePhaseService.test.js` to verify that the approval phase can be opened without an Approver resource for AI_ONLY challenges.