### PR TITLE
PM-5161: Guard MM winner fallback final scoring

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -263,14 +263,14 @@ function getReviewSummationTimestampValue(summation) {
 }
 
 /**
- * Compares two final review summations for the same submission or submitter.
+ * Compares two review summations for the same submission or submitter.
  * Newer summations win; ties keep the higher score.
  *
  * @param {Object|null} current currently selected summation
  * @param {Object} candidate summation being considered
  * @returns {Boolean} true when candidate should replace current
  */
-function shouldReplaceSelectedFinalSummation(current, candidate) {
+function shouldReplaceSelectedReviewSummation(current, candidate) {
   if (!current) {
     return true;
   }
@@ -285,20 +285,54 @@ function shouldReplaceSelectedFinalSummation(current, candidate) {
 }
 
 /**
+ * Finds the newest submission-scoped review summation per submitter.
+ *
+ * This is used as a fallback completeness signal when latest submission rows
+ * cannot be read directly from the review database.
+ *
+ * @param {Array<Object>} reviewSummations review summations returned by Review API
+ * @returns {Map<String, Object>} latest submission-scoped summation by submitter id
+ */
+function getLatestSubmissionScopedSummationsBySubmitter(reviewSummations) {
+  const latestBySubmitter = new Map();
+
+  (Array.isArray(reviewSummations) ? reviewSummations : []).forEach((summation) => {
+    const submitterId = normalizeMatchId(summation.submitterId);
+    const submissionId = normalizeMatchId(summation.submissionId);
+    if (!submitterId || !submissionId) {
+      return;
+    }
+
+    if (shouldReplaceSelectedReviewSummation(latestBySubmitter.get(submitterId), summation)) {
+      latestBySubmitter.set(submitterId, summation);
+    }
+  });
+
+  return latestBySubmitter;
+}
+
+/**
  * Selects the final summations that should determine Marathon Match winners.
  *
  * When latest submission rows are available, every latest submission must have
- * a matching final summation. Without submission rows, the function falls back
- * to the newest final summation per submitter to preserve legacy behavior while
- * avoiding duplicate winner placements for repeated attempts.
+ * a matching final summation. Without submission rows, the function uses the
+ * newest submission-scoped summation per submitter as a fallback completeness
+ * signal before ranking the newest final summation per submitter.
  *
  * @param {String} challengeId challenge identifier used in error messages
+ * @param {Array<Object>} reviewSummations all review summations
  * @param {Array<Object>} finalSummations final review summations
  * @param {Array<Object>} latestSubmissions latest submission rows
  * @returns {Array<Object>} selected final summations to rank
- * @throws {BadRequestError} when any latest submission has no final summation
+ * @throws {BadRequestError} when any latest submission or fallback latest
+ * submitter summation has no final summation
  */
-function selectMarathonMatchWinnerSummations(challengeId, finalSummations, latestSubmissions) {
+function selectMarathonMatchWinnerSummations(
+  challengeId,
+  reviewSummations,
+  finalSummations,
+  latestSubmissions,
+) {
   if (!Array.isArray(latestSubmissions) || latestSubmissions.length === 0) {
     const latestBySubmitter = new Map();
     finalSummations.forEach((summation) => {
@@ -306,10 +340,32 @@ function selectMarathonMatchWinnerSummations(challengeId, finalSummations, lates
       if (!submitterId) {
         return;
       }
-      if (shouldReplaceSelectedFinalSummation(latestBySubmitter.get(submitterId), summation)) {
+      if (shouldReplaceSelectedReviewSummation(latestBySubmitter.get(submitterId), summation)) {
         latestBySubmitter.set(submitterId, summation);
       }
     });
+
+    const latestKnownSummations = getLatestSubmissionScopedSummationsBySubmitter(reviewSummations);
+    const missingSubmitters = [];
+    latestKnownSummations.forEach((latestSummation, submitterId) => {
+      const selectedFinal = latestBySubmitter.get(submitterId);
+      if (
+        !selectedFinal ||
+        normalizeMatchId(selectedFinal.submissionId) !==
+          normalizeMatchId(latestSummation.submissionId)
+      ) {
+        missingSubmitters.push(submitterId);
+      }
+    });
+
+    if (missingSubmitters.length > 0) {
+      throw new errors.BadRequestError(
+        `Cannot close Marathon Match challenge ${challengeId}: final system scoring is not complete for latest submitter summations. Missing final summations for submitterIds: ${missingSubmitters
+          .sort()
+          .join(", ")}`,
+      );
+    }
+
     return Array.from(latestBySubmitter.values());
   }
 
@@ -321,7 +377,7 @@ function selectMarathonMatchWinnerSummations(challengeId, finalSummations, lates
       return;
     }
     const key = `${submitterId}:${submissionId}`;
-    if (shouldReplaceSelectedFinalSummation(finalBySubmission.get(key), summation)) {
+    if (shouldReplaceSelectedReviewSummation(finalBySubmission.get(key), summation)) {
       finalBySubmission.set(key, summation);
     }
   });
@@ -5525,6 +5581,7 @@ async function closeMarathonMatch(currentUser, challengeId) {
   const latestSubmissions = await getLatestMarathonMatchSubmissions(challengeId);
   const winnerSummations = selectMarathonMatchWinnerSummations(
     challengeId,
+    reviewSummations,
     finalSummations,
     latestSubmissions,
   );

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -3179,6 +3179,61 @@ describe("challenge service unit tests", () => {
       throw new Error("should not reach here");
     });
 
+    it("close marathon match blocks fallback selection when a newer submitter summation is not final", async () => {
+      const originalGetReviewSummations = helper.getReviewSummations;
+      helper.getReviewSummations = async () => [
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: true,
+          aggregateScore: 75.8,
+          submissionId: "old-topacc-submission",
+          submitterId: "12345678",
+          submitterHandle: "thomaskranitsas",
+          createdAt: "2024-05-03T09:15:00.000Z",
+          reviewedDate: "2024-05-03T09:15:00.000Z",
+        },
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: false,
+          aggregateScore: 95.7,
+          submissionId: "latest-topacc-submission",
+          submitterId: "12345678",
+          submitterHandle: "thomaskranitsas",
+          createdAt: "2024-05-03T10:15:00.000Z",
+          reviewedDate: "2024-05-03T10:15:00.000Z",
+        },
+        {
+          id: uuid(),
+          challengeId: data.marathonMatchChallenge.id,
+          isFinal: true,
+          aggregateScore: 83.6,
+          submissionId: "latest-liuliquan-submission",
+          submitterId: "9876543",
+          submitterHandle: "tonyj",
+          createdAt: "2024-05-03T10:20:00.000Z",
+          reviewedDate: "2024-05-03T10:20:00.000Z",
+        },
+      ];
+      originalReviewSummations = originalGetReviewSummations;
+
+      try {
+        await service.closeMarathonMatch(adminUser, data.marathonMatchChallenge.id);
+      } catch (e) {
+        should.equal(e.name, "BadRequestError");
+        should.equal(
+          e.message.indexOf(
+            "final system scoring is not complete for latest submitter summations",
+          ) >= 0,
+          true,
+        );
+        should.equal(e.message.indexOf("12345678") >= 0, true);
+        return;
+      }
+      throw new Error("should not reach here");
+    });
+
     it("close marathon match successfully with M2M token", async () => {
       const originalGetReviewSummations = helper.getReviewSummations;
       helper.getReviewSummations = async () => [


### PR DESCRIPTION
What was broken

Marathon Match close could still persist winners from an incomplete set of final summations when latest submission rows were unavailable to challenge-api. In that fallback path, an older or partial final score could be selected before another submitter's latest known summation had a final score.

Root cause (if identifiable)

The previous fix guarded the direct latest-submission path, but the no-submission-row fallback still ranked the newest final summation per submitter without checking whether Review API already showed a newer submission-scoped summation for that submitter.

What was changed

The fallback winner selection now derives the newest submission-scoped summation per submitter from all review summations. If that latest known submission does not have the selected final summation, closeMarathonMatch rejects the close instead of persisting premature winners.

Any added/updated tests

Added ChallengeService unit coverage for blocking fallback winner selection when a submitter has an older final summation and a newer non-final submission-scoped summation.

Validation notes:
- pnpm lint passed.
- The exact new regression test passed.
- node --check and git diff --check passed.
- pnpm build could not run because this repo has no build script.
- pnpm test is blocked before this change by test/unit/challenge-helper.test.js referencing an undefined chai global.
- The broader close marathon match focused test reaches this change; the new regression and existing blocking cases pass, while existing close success cases are blocked by missing Auth0/M2M test config.
