### PR TITLE
PM-5361: Preserve phase schedule updates by id

### DIFF
--- a/src/common/phase-helper.js
+++ b/src/common/phase-helper.js
@@ -65,6 +65,29 @@ function recalculateScheduledEndDate(phase) {
     .toISOString();
 }
 
+/**
+ * Find the incoming update payload for a persisted challenge phase.
+ * This helper does not raise exceptions.
+ *
+ * @param {Array<Object>} newPhases phase updates from the challenge update request
+ * @param {Object} phase persisted challenge phase being updated
+ * @returns {Object|undefined} the matching phase update, preferring challenge phase row id
+ */
+function findPhaseUpdate(newPhases, phase) {
+  if (!Array.isArray(newPhases)) {
+    return undefined;
+  }
+
+  if (!_.isNil(phase.id)) {
+    const phaseUpdate = _.find(newPhases, (p) => p.id === phase.id);
+    if (!_.isNil(phaseUpdate)) {
+      return phaseUpdate;
+    }
+  }
+
+  return _.find(newPhases, (p) => p.phaseId === phase.phaseId);
+}
+
 class ChallengePhaseHelper {
   phaseDefinitionMap = {};
   timelineTemplateMap = {};
@@ -182,7 +205,7 @@ class ChallengePhaseHelper {
     const updatedPhases = _.map(challengePhasesOrdered, (phase) => {
       const phaseFromTemplate = timelineTemplateMap.get(phase.phaseId);
       const phaseDefinition = phaseDefinitionMap.get(phase.phaseId);
-      const newPhase = _.find(newPhases, (p) => p.phaseId === phase.phaseId);
+      const newPhase = findPhaseUpdate(newPhases, phase);
       const templatePredecessor = _.get(phaseFromTemplate, "predecessor");
       // Prefer template predecessor only when that phase exists on the challenge, otherwise keep the stored link.
       const resolvedPredecessor = _.isNil(phaseFromTemplate)

--- a/test/unit/challenge-helper.test.js
+++ b/test/unit/challenge-helper.test.js
@@ -1,6 +1,7 @@
 require("../../app-bootstrap");
 
-const { expect } = require("chai");
+const chai = require("chai");
+const { expect } = chai;
 const { ChallengeStatusEnum } = require("@prisma/client");
 const challengeHelper = require("../../src/common/challenge-helper");
 

--- a/test/unit/phase-helper.test.js
+++ b/test/unit/phase-helper.test.js
@@ -99,6 +99,73 @@ describe('phase helper unit tests', () => {
     updatedPhases[1].duration.should.equal(4 * 24 * 60 * 60)
   })
 
+  it('matches launched phase updates by challenge phase id before phase definition id', async () => {
+    const sharedPhaseId = 'shared-registration-phase'
+    const staleDuration = 120 * 60 * 60
+    const firstPhaseStartDate = '2026-06-15T09:29:45.575Z'
+    const secondPhaseStartDate = '2026-06-15T09:29:45.576Z'
+    const firstPhaseEndDate = '2026-06-20T10:14:45.575Z'
+    const secondPhaseEndDate = '2026-06-20T11:44:45.576Z'
+
+    stubPhaseLookups(
+      [{ id: sharedPhaseId, name: 'Registration', description: 'Registration phase' }],
+      [{ phaseId: sharedPhaseId, defaultDuration: staleDuration }]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          id: 'first-challenge-phase',
+          duration: staleDuration,
+          name: 'Registration',
+          phaseId: sharedPhaseId,
+          isOpen: true,
+          scheduledStartDate: firstPhaseStartDate,
+          scheduledEndDate: '2026-06-20T09:29:45.575Z',
+          actualStartDate: firstPhaseStartDate,
+          actualEndDate: null
+        },
+        {
+          id: 'second-challenge-phase',
+          duration: staleDuration,
+          name: 'Registration',
+          phaseId: sharedPhaseId,
+          isOpen: true,
+          scheduledStartDate: secondPhaseStartDate,
+          scheduledEndDate: '2026-06-20T09:29:45.576Z',
+          actualStartDate: secondPhaseStartDate,
+          actualEndDate: null
+        }
+      ],
+      [
+        {
+          id: 'first-challenge-phase',
+          duration: staleDuration,
+          phaseId: sharedPhaseId,
+          scheduledEndDate: firstPhaseEndDate,
+          scheduledStartDate: firstPhaseStartDate
+        },
+        {
+          id: 'second-challenge-phase',
+          duration: staleDuration,
+          phaseId: sharedPhaseId,
+          scheduledEndDate: secondPhaseEndDate,
+          scheduledStartDate: secondPhaseStartDate
+        }
+      ],
+      'timeline-template-id',
+      false
+    )
+
+    const firstUpdatedPhase = updatedPhases.find((phase) => phase.id === 'first-challenge-phase')
+    const secondUpdatedPhase = updatedPhases.find((phase) => phase.id === 'second-challenge-phase')
+
+    firstUpdatedPhase.scheduledEndDate.should.equal(firstPhaseEndDate)
+    firstUpdatedPhase.duration.should.equal(120 * 60 * 60 + 45 * 60)
+    secondUpdatedPhase.scheduledEndDate.should.equal(secondPhaseEndDate)
+    secondUpdatedPhase.duration.should.equal(122 * 60 * 60 + 15 * 60)
+  })
+
   it('uses scheduled end dates from update payload for MM phases', async () => {
     const registrationPhaseId = 'mm-registration-phase'
     const submissionPhaseId = 'mm-submission-phase'


### PR DESCRIPTION
What was broken
Launched challenges with schedule updates could apply the wrong incoming phase payload when multiple challenge phase rows shared a phase definition id. That could make edited end dates and minute durations appear to revert after save for some timelines.

Root cause (if identifiable)
populatePhasesForChallengeUpdate matched incoming phase edits only by phaseId, which identifies the phase definition rather than the persisted challenge phase row.

What was changed
Added a phase update lookup that prefers the persisted challenge phase id and falls back to the existing phaseId behavior for compatibility. Kept the existing scheduledEndDate duration recalculation behavior intact. Fixed a missing Chai binding in challenge-helper tests so the unit command can load that file.

Any added/updated tests
Added phase-helper regression coverage for launched open phases that share a phase definition id and must preserve distinct scheduledEndDate and duration updates.

Validation
Focused changed-file unit tests passed: pnpm exec mocha --require ./app-bootstrap.js test/unit/phase-helper.test.js test/unit/challenge-helper.test.js --exit
Lint passed: pnpm lint
The package test command, pnpm test, is still blocked by repo-level local test setup issues: without DATABASE_URL it reports Prisma DATABASE_URL failures; with an isolated local schema and app bootstrap it reaches 162 passing and 149 existing service-suite failures.
Build could not run because this package does not define a build script for pnpm build.
