### PR TITLE
PM-5378: Allow Design active phase shortening in API

### DIFF
--- a/src/common/phase-helper.js
+++ b/src/common/phase-helper.js
@@ -9,6 +9,120 @@ const timelineTemplateService = require("../services/TimelineTemplateService");
 const prisma = require("../common/prisma").getClient();
 
 const SUBMISSION_PHASE_PRIORITY = ["Topgear Submission", "Topcoder Submission", "Submission"];
+const DESIGN_TRACK = "DESIGN";
+
+/**
+ * Resolve a track object or token to the canonical track value used in challenge metadata.
+ *
+ * @param {Object|String|null|undefined} track challenge track relation, display value, or token
+ * @returns {String} normalized uppercase track token
+ */
+function normalizeTrackToken(track) {
+  if (_.isNil(track)) {
+    return "";
+  }
+
+  if (_.isString(track)) {
+    return _.toUpper(_.trim(track));
+  }
+
+  return _.toUpper(
+    _.trim(
+      _.get(track, "track") ||
+        _.get(track, "name") ||
+        _.get(track, "abbreviation") ||
+        ""
+    )
+  );
+}
+
+/**
+ * Check whether a challenge track represents Design.
+ *
+ * @param {Object|String|null|undefined} track challenge track relation, display value, or token
+ * @returns {Boolean} true when the track is Design
+ */
+function isDesignTrack(track) {
+  return normalizeTrackToken(track) === DESIGN_TRACK;
+}
+
+/**
+ * Resolve the requested scheduled end date from a phase update payload.
+ *
+ * @param {Object} phase existing challenge phase
+ * @param {Object|null|undefined} newPhase phase update payload
+ * @returns {Date|String|undefined} requested scheduled end date when the payload changes it
+ */
+function resolveRequestedScheduledEndDate(phase, newPhase) {
+  if (_.isNil(newPhase)) {
+    return undefined;
+  }
+
+  if (!_.isNil(_.get(newPhase, "scheduledEndDate"))) {
+    return _.get(newPhase, "scheduledEndDate");
+  }
+
+  const requestedDuration = _.get(newPhase, "duration");
+  if (_.isNil(requestedDuration) || _.isNil(phase.scheduledStartDate)) {
+    return undefined;
+  }
+
+  const scheduledStart = moment(phase.scheduledStartDate);
+  if (!scheduledStart.isValid()) {
+    return undefined;
+  }
+
+  return scheduledStart.add(requestedDuration, "seconds").toDate().toISOString();
+}
+
+/**
+ * Validate an active phase scheduled end date change against PM-5378 rules.
+ *
+ * @param {Object} phase existing challenge phase
+ * @param {Date|String|null|undefined} requestedScheduledEndDate requested scheduled end date
+ * @param {Object} options validation options
+ * @param {Boolean} options.allowActivePhaseShortening whether active phase shortening is allowed
+ * @returns {undefined} validates only
+ * @throws {BadRequestError} when active phase shortening is disallowed or would end in the past
+ */
+function validateActivePhaseScheduledEndDateChange(
+  phase,
+  requestedScheduledEndDate,
+  options = {}
+) {
+  if (_.isNil(phase) || phase.isOpen !== true || _.isNil(requestedScheduledEndDate)) {
+    return;
+  }
+
+  const requestedEnd = moment(requestedScheduledEndDate);
+  if (!requestedEnd.isValid()) {
+    return;
+  }
+
+  const currentEnd = moment(phase.scheduledEndDate);
+  const hasCurrentEnd = currentEnd.isValid();
+  const hasChangedEndDate = !hasCurrentEnd || requestedEnd.valueOf() !== currentEnd.valueOf();
+
+  if (!hasChangedEndDate) {
+    return;
+  }
+
+  if (requestedEnd.isBefore(moment())) {
+    throw new errors.BadRequestError(
+      "Active phase scheduledEndDate cannot be set before the current date/time."
+    );
+  }
+
+  if (
+    hasCurrentEnd &&
+    requestedEnd.isBefore(currentEnd) &&
+    options.allowActivePhaseShortening !== true
+  ) {
+    throw new errors.BadRequestError(
+      "Active phases can only be shortened for Design track challenges."
+    );
+  }
+}
 
 /**
  * Apply an explicit scheduled end date to a phase and update its duration.
@@ -142,7 +256,8 @@ class ChallengePhaseHelper {
     challengePhases,
     newPhases,
     timelineTemplateId,
-    isBeingActivated
+    isBeingActivated,
+    options = {}
   ) {
     const { timelineTemplateMap, timelineTempate } = await this.getTemplateAndTemplateMap(
       timelineTemplateId
@@ -183,6 +298,11 @@ class ChallengePhaseHelper {
       const phaseFromTemplate = timelineTemplateMap.get(phase.phaseId);
       const phaseDefinition = phaseDefinitionMap.get(phase.phaseId);
       const newPhase = _.find(newPhases, (p) => p.phaseId === phase.phaseId);
+      validateActivePhaseScheduledEndDateChange(
+        phase,
+        resolveRequestedScheduledEndDate(phase, newPhase),
+        options
+      );
       const templatePredecessor = _.get(phaseFromTemplate, "predecessor");
       // Prefer template predecessor only when that phase exists on the challenge, otherwise keep the stored link.
       const resolvedPredecessor = _.isNil(phaseFromTemplate)
@@ -339,6 +459,29 @@ class ChallengePhaseHelper {
       };
     }
     return this.timelineTemplateMap[timelineTemplateId];
+  }
+
+  /**
+   * Check whether a challenge track represents Design.
+   *
+   * @param {Object|String|null|undefined} track challenge track relation, display value, or token
+   * @returns {Boolean} true when the track is Design
+   */
+  isDesignTrack(track) {
+    return isDesignTrack(track);
+  }
+
+  /**
+   * Validate an active phase scheduled end date change against PM-5378 rules.
+   *
+   * @param {Object} phase existing challenge phase
+   * @param {Date|String|null|undefined} requestedScheduledEndDate requested scheduled end date
+   * @param {Object} options validation options
+   * @returns {undefined} validates only
+   * @throws {BadRequestError} when active phase shortening is disallowed or would end in the past
+   */
+  validateActivePhaseScheduledEndDateChange(phase, requestedScheduledEndDate, options = {}) {
+    validateActivePhaseScheduledEndDateChange(phase, requestedScheduledEndDate, options);
   }
 }
 

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -11,6 +11,7 @@ const logger = require("../common/logger");
 const errors = require("../common/errors");
 const constants = require("../../app-constants");
 const { getReviewClient } = require("../common/review-prisma");
+const phaseHelper = require("../common/phase-helper");
 const {
   indexChallengeAndPostToKafka,
   ensureAIPhaseCanBeClosed,
@@ -48,18 +49,6 @@ function datesAreSame(dateA, dateB) {
     return false;
   }
   return new Date(dateA).getTime() === new Date(dateB).getTime();
-}
-
-function dateIsAfter(dateA, dateB) {
-  if (_.isNil(dateA) || _.isNil(dateB)) {
-    return false;
-  }
-  const timeA = new Date(dateA).getTime();
-  const timeB = new Date(dateB).getTime();
-  if (Number.isNaN(timeA) || Number.isNaN(timeB)) {
-    return false;
-  }
-  return timeA > timeB;
 }
 
 function buildPhaseIdentifiers(phase) {
@@ -479,13 +468,13 @@ async function hasPendingEscalationRequestsForChallenge(challengeId) {
 /**
  * Load a challenge for challenge-scoped phase operations.
  * @param {String} challengeId the challenge id
- * @returns {Object} the challenge with the given id and type metadata
+ * @returns {Object} the challenge with the given id and type/track metadata
  * @throws {NotFoundError} when the challenge does not exist
  */
 async function getChallengeForPhaseAccess(challengeId) {
   const challenge = await prisma.challenge.findUnique({
     where: { id: challengeId },
-    include: { type: true },
+    include: { track: true, type: true },
   });
   if (!challenge) {
     throw new errors.NotFoundError(`Challenge with id: ${challengeId} doesn't exist`);
@@ -928,6 +917,11 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       }
     }
   }
+  phaseHelper.validateActivePhaseScheduledEndDateChange(
+    challengePhase,
+    data.scheduledEndDate,
+    { allowActivePhaseShortening: phaseHelper.isDesignTrack(challenge.track) }
+  );
   const dataToUpdate = _.omit(data, "constraints");
   const shouldRefreshPhaseNames =
     Object.prototype.hasOwnProperty.call(data, "isOpen") ||
@@ -939,10 +933,10 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
         id: challengePhase.id,
       },
     });
-    let scheduleExtended = false;
+    let scheduleEndChanged = false;
     if (shouldAttemptSuccessorRecalc) {
-      scheduleExtended = dateIsAfter(updatedPhase.scheduledEndDate, originalScheduledEndDate);
-      if (scheduleExtended) {
+      scheduleEndChanged = !datesAreSame(updatedPhase.scheduledEndDate, originalScheduledEndDate);
+      if (scheduleEndChanged) {
         await recalculateDependentPhaseDates(tx, challengeId, updatedPhase, currentUserId);
       }
     }
@@ -952,7 +946,7 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       !_.isNil(updatedPhase.actualEndDate)
     ) {
       const shiftBaselineScheduledEndDate =
-        scheduleExtended && !_.isNil(updatedPhase.scheduledEndDate)
+        scheduleEndChanged && !_.isNil(updatedPhase.scheduledEndDate)
           ? updatedPhase.scheduledEndDate
           : originalScheduledEndDate;
       const scheduledEndTime = new Date(shiftBaselineScheduledEndDate).getTime();

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -3848,6 +3848,7 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
 
   let isChallengeBeingActivated = isStatusChangingToActive;
   let isChallengeBeingCancelled = false;
+  const allowActivePhaseShortening = phaseHelper.isDesignTrack(challenge.track);
   const isStatusChangingToCancelled =
     isCancelledChallengeStatus(data.status) && !isCancelledChallengeStatus(challenge.status);
   if (data.status) {
@@ -4045,6 +4046,7 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
         data.phases,
         challenge.timelineTemplateId,
         isChallengeBeingActivated,
+        { allowActivePhaseShortening },
       );
     }
     phasesUpdated = true;

--- a/test/unit/ChallengePhaseService.test.js
+++ b/test/unit/ChallengePhaseService.test.js
@@ -1401,6 +1401,141 @@ describe('challenge phase service unit tests', () => {
       }
     })
 
+    it('partially update challenge phase - allows Design active phase shortening and recalculates successor schedules', async function () {
+      this.timeout(50000)
+      const originalChallenge = await prisma.challenge.findUnique({
+        where: { id: data.challenge.id },
+        select: { trackId: true }
+      })
+      let designTrack
+      let reviewPhase
+      let appealsPhase
+      const reviewChallengePhaseId = uuid()
+      const appealsChallengePhaseId = uuid()
+      const now = Date.now()
+      const reviewStartDate = new Date(now - 60 * 60 * 1000)
+      const reviewEndDate = new Date(now + 4 * 24 * 60 * 60 * 1000)
+      const shortenedReviewEndDate = new Date(now + 2 * 24 * 60 * 60 * 1000)
+      const reviewDuration = Math.round(
+        (reviewEndDate.getTime() - reviewStartDate.getTime()) / 1000
+      )
+      const appealsDuration = 43200
+
+      try {
+        designTrack = await prisma.challengeTrack.create({
+          data: {
+            id: uuid(),
+            name: `Design ${shortId()}`,
+            description: 'Design track for active phase shortening tests',
+            isActive: true,
+            abbreviation: `D${shortId()}`,
+            track: 'DESIGN',
+            createdBy: 'admin',
+            updatedBy: 'admin'
+          }
+        })
+        await prisma.challenge.update({
+          where: { id: data.challenge.id },
+          data: { trackId: designTrack.id }
+        })
+
+        reviewPhase = await prisma.phase.create({
+          data: {
+            id: uuid(),
+            name: 'Review',
+            description: 'desc',
+            isOpen: false,
+            duration: 86400,
+            createdBy: 'admin',
+            updatedBy: 'admin'
+          }
+        })
+        appealsPhase = await prisma.phase.create({
+          data: {
+            id: uuid(),
+            name: 'Appeals',
+            description: 'desc',
+            isOpen: false,
+            duration: appealsDuration,
+            createdBy: 'admin',
+            updatedBy: 'admin'
+          }
+        })
+
+        await prisma.challengePhase.createMany({
+          data: [
+            {
+              id: reviewChallengePhaseId,
+              challengeId: data.challenge.id,
+              phaseId: reviewPhase.id,
+              name: 'Review',
+              duration: reviewDuration,
+              isOpen: true,
+              actualStartDate: reviewStartDate,
+              scheduledStartDate: reviewStartDate,
+              scheduledEndDate: reviewEndDate,
+              createdBy: 'admin',
+              updatedBy: 'admin'
+            },
+            {
+              id: appealsChallengePhaseId,
+              challengeId: data.challenge.id,
+              phaseId: appealsPhase.id,
+              predecessor: reviewPhase.id,
+              name: 'Appeals',
+              duration: appealsDuration,
+              scheduledStartDate: reviewEndDate,
+              scheduledEndDate: new Date(reviewEndDate.getTime() + appealsDuration * 1000),
+              createdBy: 'admin',
+              updatedBy: 'admin'
+            }
+          ]
+        })
+
+        const updatedReview = await service.partiallyUpdateChallengePhase(
+          authUser,
+          data.challenge.id,
+          reviewChallengePhaseId,
+          { scheduledEndDate: shortenedReviewEndDate }
+        )
+
+        should.equal(
+          new Date(updatedReview.scheduledEndDate).toISOString(),
+          shortenedReviewEndDate.toISOString()
+        )
+
+        const updatedAppeals = await prisma.challengePhase.findUnique({
+          where: { id: appealsChallengePhaseId }
+        })
+        should.equal(
+          new Date(updatedAppeals.scheduledStartDate).toISOString(),
+          shortenedReviewEndDate.toISOString()
+        )
+        should.equal(
+          new Date(updatedAppeals.scheduledEndDate).toISOString(),
+          new Date(shortenedReviewEndDate.getTime() + appealsDuration * 1000).toISOString()
+        )
+      } finally {
+        await prisma.challengePhase.deleteMany({
+          where: { id: { in: [reviewChallengePhaseId, appealsChallengePhaseId] } }
+        })
+        if (reviewPhase || appealsPhase) {
+          await prisma.phase.deleteMany({
+            where: { id: { in: _.compact([reviewPhase?.id, appealsPhase?.id]) } }
+          })
+        }
+        if (originalChallenge) {
+          await prisma.challenge.update({
+            where: { id: data.challenge.id },
+            data: { trackId: originalChallenge.trackId }
+          })
+        }
+        if (designTrack) {
+          await prisma.challengeTrack.delete({ where: { id: designTrack.id } })
+        }
+      }
+    })
+
     it('partially update challenge phase - cannot close Appeals Response when appeals lack responses', async function () {
       this.timeout(50000)
       const appealsPhaseId = uuid()

--- a/test/unit/phase-helper.test.js
+++ b/test/unit/phase-helper.test.js
@@ -163,4 +163,154 @@ describe('phase helper unit tests', () => {
     updatedPhases[1].scheduledEndDate.should.equal(submissionEndDate)
     updatedPhases[1].duration.should.equal(3 * 24 * 60 * 60)
   })
+
+  it('allows active Design phases to be shortened to a future end date', async () => {
+    const registrationPhaseId = 'design-registration-phase'
+    const submissionPhaseId = 'design-submission-phase'
+    const staleDuration = 5 * 24 * 60 * 60
+    const registrationStartDate = '2099-05-26T05:14:00.000Z'
+    const currentRegistrationEndDate = '2099-05-31T05:14:00.000Z'
+    const shortenedRegistrationEndDate = '2099-05-29T05:14:00.000Z'
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' },
+        { id: submissionPhaseId, name: 'Submission', description: 'Submission phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: staleDuration },
+        {
+          phaseId: submissionPhaseId,
+          predecessor: registrationPhaseId,
+          defaultDuration: staleDuration
+        }
+      ]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          duration: staleDuration,
+          isOpen: true,
+          name: 'Registration',
+          phaseId: registrationPhaseId,
+          scheduledStartDate: registrationStartDate,
+          scheduledEndDate: currentRegistrationEndDate
+        },
+        {
+          duration: staleDuration,
+          name: 'Submission',
+          phaseId: submissionPhaseId,
+          predecessor: registrationPhaseId,
+          scheduledStartDate: currentRegistrationEndDate,
+          scheduledEndDate: '2099-06-05T05:14:00.000Z'
+        }
+      ],
+      [
+        {
+          phaseId: registrationPhaseId,
+          scheduledEndDate: shortenedRegistrationEndDate
+        }
+      ],
+      'timeline-template-id',
+      false,
+      { allowActivePhaseShortening: true }
+    )
+
+    updatedPhases[0].scheduledEndDate.should.equal(shortenedRegistrationEndDate)
+    updatedPhases[0].duration.should.equal(3 * 24 * 60 * 60)
+    updatedPhases[1].scheduledStartDate.should.equal(shortenedRegistrationEndDate)
+  })
+
+  it('rejects active phase shortening for non-Design tracks', async () => {
+    const registrationPhaseId = 'development-registration-phase'
+    const staleDuration = 5 * 24 * 60 * 60
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: staleDuration }
+      ]
+    )
+
+    try {
+      await phaseHelper.populatePhasesForChallengeUpdate(
+        [
+          {
+            duration: staleDuration,
+            isOpen: true,
+            name: 'Registration',
+            phaseId: registrationPhaseId,
+            scheduledStartDate: '2099-05-26T05:14:00.000Z',
+            scheduledEndDate: '2099-05-31T05:14:00.000Z'
+          }
+        ],
+        [
+          {
+            phaseId: registrationPhaseId,
+            scheduledEndDate: '2099-05-29T05:14:00.000Z'
+          }
+        ],
+        'timeline-template-id',
+        false,
+        { allowActivePhaseShortening: false }
+      )
+    } catch (e) {
+      e.message.should.equal('Active phases can only be shortened for Design track challenges.')
+      return
+    }
+
+    throw new Error('should not reach here')
+  })
+
+  it('rejects active phase end dates before the current date/time', async () => {
+    const registrationPhaseId = 'past-registration-phase'
+    const now = Date.now()
+    const registrationStartDate = new Date(now - 2 * 60 * 60 * 1000).toISOString()
+    const pastRegistrationEndDate = new Date(now - 60 * 60 * 1000).toISOString()
+    const currentRegistrationEndDate = new Date(now + 24 * 60 * 60 * 1000).toISOString()
+    const staleDuration = 24 * 60 * 60
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: staleDuration }
+      ]
+    )
+
+    try {
+      await phaseHelper.populatePhasesForChallengeUpdate(
+        [
+          {
+            duration: staleDuration,
+            isOpen: true,
+            name: 'Registration',
+            phaseId: registrationPhaseId,
+            scheduledStartDate: registrationStartDate,
+            scheduledEndDate: currentRegistrationEndDate
+          }
+        ],
+        [
+          {
+            phaseId: registrationPhaseId,
+            scheduledEndDate: pastRegistrationEndDate
+          }
+        ],
+        'timeline-template-id',
+        false,
+        { allowActivePhaseShortening: true }
+      )
+    } catch (e) {
+      e.message.should.equal(
+        'Active phase scheduledEndDate cannot be set before the current date/time.'
+      )
+      return
+    }
+
+    throw new Error('should not reach here')
+  })
 })


### PR DESCRIPTION
What was broken
Active phase end dates could only move later. The API rejected shortening even for Design challenges, and direct phase updates only recalculated successor schedules when an end date was extended.

Root cause
The phase validation did not account for challenge track, and successor recalculation used an extended-only check.

What was changed
Added track-aware active phase end-date validation that allows Design track shortening while blocking end dates before the current date/time. Wired it into challenge updates and direct phase updates, and recalculated dependent phases whenever the active end date changes.

Any added/updated tests
Added phase-helper coverage for Design shortening, non-Design rejection, and past end-date rejection. Added a ChallengePhaseService regression test for Design shortening and successor schedule recalculation.
