### PR TITLE
PM-5378: Allow Design shortening across phases

### DIFF
--- a/src/common/phase-helper.js
+++ b/src/common/phase-helper.js
@@ -76,21 +76,26 @@ function resolveRequestedScheduledEndDate(phase, newPhase) {
 }
 
 /**
- * Validate an active phase scheduled end date change against PM-5378 rules.
+ * Validate a phase scheduled end date change against PM-5378 rules.
  *
  * @param {Object} phase existing challenge phase
  * @param {Date|String|null|undefined} requestedScheduledEndDate requested scheduled end date
  * @param {Object} options validation options
- * @param {Boolean} options.allowActivePhaseShortening whether active phase shortening is allowed
+ * @param {Boolean} options.allowActivePhaseShortening whether Design track phase shortening is allowed
+ * @param {Boolean} options.preventPhaseShortening whether shortening is guarded for all incomplete phases
  * @returns {undefined} validates only
- * @throws {BadRequestError} when active phase shortening is disallowed or would end in the past
+ * @throws {BadRequestError} when phase shortening is disallowed or would end in the past
  */
 function validateActivePhaseScheduledEndDateChange(
   phase,
   requestedScheduledEndDate,
   options = {}
 ) {
-  if (_.isNil(phase) || phase.isOpen !== true || _.isNil(requestedScheduledEndDate)) {
+  if (!_.isNil(phase?.actualEndDate)) {
+    return;
+  }
+
+  if (_.isNil(phase) || _.isNil(requestedScheduledEndDate)) {
     return;
   }
 
@@ -107,19 +112,25 @@ function validateActivePhaseScheduledEndDateChange(
     return;
   }
 
-  if (requestedEnd.isBefore(moment())) {
+  const shouldValidatePhaseEnd =
+    phase.isOpen === true ||
+    options.allowActivePhaseShortening === true ||
+    options.preventPhaseShortening === true;
+  const isShortened = hasCurrentEnd && requestedEnd.isBefore(currentEnd);
+
+  if (shouldValidatePhaseEnd && requestedEnd.isBefore(moment())) {
     throw new errors.BadRequestError(
-      "Active phase scheduledEndDate cannot be set before the current date/time."
+      "Phase scheduledEndDate cannot be set before the current date/time."
     );
   }
 
   if (
-    hasCurrentEnd &&
-    requestedEnd.isBefore(currentEnd) &&
-    options.allowActivePhaseShortening !== true
+    isShortened &&
+    options.allowActivePhaseShortening !== true &&
+    (phase.isOpen === true || options.preventPhaseShortening === true)
   ) {
     throw new errors.BadRequestError(
-      "Active phases can only be shortened for Design track challenges."
+      "Challenge phase schedules can only be shortened for Design track challenges."
     );
   }
 }
@@ -320,7 +331,7 @@ class ChallengePhaseHelper {
     const updatedPhases = _.map(challengePhasesOrdered, (phase) => {
       const phaseFromTemplate = timelineTemplateMap.get(phase.phaseId);
       const phaseDefinition = phaseDefinitionMap.get(phase.phaseId);
-      const newPhase = _.find(newPhases, (p) => p.phaseId === phase.phaseId);
+      const newPhase = findPhaseUpdate(newPhases, phase);
       validateActivePhaseScheduledEndDateChange(
         phase,
         resolveRequestedScheduledEndDate(phase, newPhase),
@@ -495,13 +506,13 @@ class ChallengePhaseHelper {
   }
 
   /**
-   * Validate an active phase scheduled end date change against PM-5378 rules.
+   * Validate a phase scheduled end date change against PM-5378 rules.
    *
    * @param {Object} phase existing challenge phase
    * @param {Date|String|null|undefined} requestedScheduledEndDate requested scheduled end date
    * @param {Object} options validation options
    * @returns {undefined} validates only
-   * @throws {BadRequestError} when active phase shortening is disallowed or would end in the past
+   * @throws {BadRequestError} when phase shortening is disallowed or would end in the past
    */
   validateActivePhaseScheduledEndDateChange(phase, requestedScheduledEndDate, options = {}) {
     validateActivePhaseScheduledEndDateChange(phase, requestedScheduledEndDate, options);

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -17,7 +17,7 @@ const {
   ensureAIPhaseCanBeClosed,
 } = require("./ChallengeService");
 
-const { getClient } = require("../common/prisma");
+const { getClient, ChallengeStatusEnum } = require("../common/prisma");
 const prisma = getClient();
 const PENDING_REVIEW_STATUSES = Object.freeze(["PENDING", "IN_PROGRESS", "DRAFT", "SUBMITTED"]);
 const REVIEW_PHASE_NAMES = Object.freeze([
@@ -648,6 +648,7 @@ getChallengePhase.schema = {
  * @param {Object} data the partial phase update
  * @returns {Object} the updated challengePhase
  * @throws {ForbiddenError} when the current user cannot modify the challenge
+ * @throws {BadRequestError} when phase schedule shortening violates track or timing rules
  */
 async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data) {
   const challenge = await getChallengeForPhaseAccess(challengeId);
@@ -917,11 +918,13 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
       }
     }
   }
-  phaseHelper.validateActivePhaseScheduledEndDateChange(
-    challengePhase,
-    data.scheduledEndDate,
-    { allowActivePhaseShortening: phaseHelper.isDesignTrack(challenge.track) }
-  );
+  const allowActivePhaseShortening = phaseHelper.isDesignTrack(challenge.track);
+  const preventPhaseShortening =
+    challenge.status === ChallengeStatusEnum.ACTIVE && !allowActivePhaseShortening;
+  phaseHelper.validateActivePhaseScheduledEndDateChange(challengePhase, data.scheduledEndDate, {
+    allowActivePhaseShortening,
+    preventPhaseShortening,
+  });
   const dataToUpdate = _.omit(data, "constraints");
   const shouldRefreshPhaseNames =
     Object.prototype.hasOwnProperty.call(data, "isOpen") ||

--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -3849,6 +3849,8 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
   let isChallengeBeingActivated = isStatusChangingToActive;
   let isChallengeBeingCancelled = false;
   const allowActivePhaseShortening = phaseHelper.isDesignTrack(challenge.track);
+  const preventPhaseShortening =
+    challenge.status === ChallengeStatusEnum.ACTIVE && !allowActivePhaseShortening;
   const isStatusChangingToCancelled =
     isCancelledChallengeStatus(data.status) && !isCancelledChallengeStatus(challenge.status);
   if (data.status) {
@@ -4046,7 +4048,7 @@ async function updateChallenge(currentUser, challengeId, data, options = {}) {
         data.phases,
         challenge.timelineTemplateId,
         isChallengeBeingActivated,
-        { allowActivePhaseShortening },
+        { allowActivePhaseShortening, preventPhaseShortening },
       );
     }
     phasesUpdated = true;

--- a/test/unit/phase-helper.test.js
+++ b/test/unit/phase-helper.test.js
@@ -1,5 +1,6 @@
 const chai = require('chai')
 
+require('../../app-bootstrap')
 const phaseHelper = require('../../src/common/phase-helper')
 
 chai.should()
@@ -289,17 +290,114 @@ describe('phase helper unit tests', () => {
     updatedPhases[1].scheduledStartDate.should.equal(shortenedRegistrationEndDate)
   })
 
+  it('allows future Design phases to be shortened to a future end date', async () => {
+    const registrationPhaseId = 'design-registration-phase'
+    const reviewPhaseId = 'design-review-phase'
+    const registrationDuration = 2 * 24 * 60 * 60
+    const reviewDuration = 5 * 24 * 60 * 60
+    const registrationStartDate = '2099-05-26T05:14:00.000Z'
+    const registrationEndDate = '2099-05-28T05:14:00.000Z'
+    const currentReviewEndDate = '2099-06-02T05:14:00.000Z'
+    const shortenedReviewEndDate = '2099-05-30T05:14:00.000Z'
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' },
+        { id: reviewPhaseId, name: 'Review', description: 'Review phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: registrationDuration },
+        {
+          phaseId: reviewPhaseId,
+          predecessor: registrationPhaseId,
+          defaultDuration: reviewDuration
+        }
+      ]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          duration: registrationDuration,
+          isOpen: true,
+          name: 'Registration',
+          phaseId: registrationPhaseId,
+          scheduledStartDate: registrationStartDate,
+          scheduledEndDate: registrationEndDate
+        },
+        {
+          duration: reviewDuration,
+          name: 'Review',
+          phaseId: reviewPhaseId,
+          predecessor: registrationPhaseId,
+          scheduledStartDate: registrationEndDate,
+          scheduledEndDate: currentReviewEndDate
+        }
+      ],
+      [
+        {
+          phaseId: reviewPhaseId,
+          scheduledEndDate: shortenedReviewEndDate
+        }
+      ],
+      'timeline-template-id',
+      false,
+      { allowActivePhaseShortening: true }
+    )
+
+    updatedPhases[1].scheduledStartDate.should.equal(registrationEndDate)
+    updatedPhases[1].scheduledEndDate.should.equal(shortenedReviewEndDate)
+    updatedPhases[1].duration.should.equal(2 * 24 * 60 * 60)
+  })
+
+  it('keeps a persisted end date when a stale duration would imply active non-Design shortening', async () => {
+    const registrationPhaseId = 'development-registration-phase'
+    const registrationStartDate = '2099-05-26T05:14:00.000Z'
+    const currentRegistrationEndDate = '2099-05-27T05:14:00.000Z'
+    const staleShortDuration = 23 * 60 * 60
+
+    stubPhaseLookups(
+      [{ id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }],
+      [{ phaseId: registrationPhaseId, defaultDuration: 6 * 24 * 60 * 60 }]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          duration: 24 * 60 * 60,
+          isOpen: true,
+          name: 'Registration',
+          phaseId: registrationPhaseId,
+          scheduledStartDate: registrationStartDate,
+          scheduledEndDate: currentRegistrationEndDate
+        }
+      ],
+      [
+        {
+          duration: staleShortDuration,
+          phaseId: registrationPhaseId,
+          scheduledEndDate: currentRegistrationEndDate
+        }
+      ],
+      'timeline-template-id',
+      false,
+      {
+        allowActivePhaseShortening: false,
+        preventPhaseShortening: true
+      }
+    )
+
+    updatedPhases[0].scheduledEndDate.should.equal(currentRegistrationEndDate)
+    updatedPhases[0].duration.should.equal(24 * 60 * 60)
+  })
+
   it('rejects active phase shortening for non-Design tracks', async () => {
     const registrationPhaseId = 'development-registration-phase'
     const staleDuration = 5 * 24 * 60 * 60
 
     stubPhaseLookups(
-      [
-        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }
-      ],
-      [
-        { phaseId: registrationPhaseId, defaultDuration: staleDuration }
-      ]
+      [{ id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }],
+      [{ phaseId: registrationPhaseId, defaultDuration: staleDuration }]
     )
 
     try {
@@ -325,11 +423,142 @@ describe('phase helper unit tests', () => {
         { allowActivePhaseShortening: false }
       )
     } catch (e) {
-      e.message.should.equal('Active phases can only be shortened for Design track challenges.')
+      e.message.should.equal(
+        'Challenge phase schedules can only be shortened for Design track challenges.'
+      )
       return
     }
 
     throw new Error('should not reach here')
+  })
+
+  it('rejects future phase shortening for active non-Design challenges', async () => {
+    const registrationPhaseId = 'development-registration-phase'
+    const reviewPhaseId = 'development-review-phase'
+    const registrationDuration = 2 * 24 * 60 * 60
+    const reviewDuration = 5 * 24 * 60 * 60
+    const registrationStartDate = '2099-05-26T05:14:00.000Z'
+    const registrationEndDate = '2099-05-28T05:14:00.000Z'
+    const currentReviewEndDate = '2099-06-02T05:14:00.000Z'
+    const shortenedReviewEndDate = '2099-05-30T05:14:00.000Z'
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' },
+        { id: reviewPhaseId, name: 'Review', description: 'Review phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: registrationDuration },
+        {
+          phaseId: reviewPhaseId,
+          predecessor: registrationPhaseId,
+          defaultDuration: reviewDuration
+        }
+      ]
+    )
+
+    try {
+      await phaseHelper.populatePhasesForChallengeUpdate(
+        [
+          {
+            duration: registrationDuration,
+            isOpen: true,
+            name: 'Registration',
+            phaseId: registrationPhaseId,
+            scheduledStartDate: registrationStartDate,
+            scheduledEndDate: registrationEndDate
+          },
+          {
+            duration: reviewDuration,
+            name: 'Review',
+            phaseId: reviewPhaseId,
+            predecessor: registrationPhaseId,
+            scheduledStartDate: registrationEndDate,
+            scheduledEndDate: currentReviewEndDate
+          }
+        ],
+        [
+          {
+            phaseId: reviewPhaseId,
+            scheduledEndDate: shortenedReviewEndDate
+          }
+        ],
+        'timeline-template-id',
+        false,
+        {
+          allowActivePhaseShortening: false,
+          preventPhaseShortening: true
+        }
+      )
+    } catch (e) {
+      e.message.should.equal(
+        'Challenge phase schedules can only be shortened for Design track challenges.'
+      )
+      return
+    }
+
+    throw new Error('should not reach here')
+  })
+
+  it('allows future non-Design phases to be shortened before launch', async () => {
+    const registrationPhaseId = 'development-registration-phase'
+    const reviewPhaseId = 'development-review-phase'
+    const registrationDuration = 2 * 24 * 60 * 60
+    const reviewDuration = 5 * 24 * 60 * 60
+    const registrationStartDate = '2099-05-26T05:14:00.000Z'
+    const registrationEndDate = '2099-05-28T05:14:00.000Z'
+    const currentReviewEndDate = '2099-06-02T05:14:00.000Z'
+    const shortenedReviewEndDate = '2099-05-30T05:14:00.000Z'
+
+    stubPhaseLookups(
+      [
+        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' },
+        { id: reviewPhaseId, name: 'Review', description: 'Review phase' }
+      ],
+      [
+        { phaseId: registrationPhaseId, defaultDuration: registrationDuration },
+        {
+          phaseId: reviewPhaseId,
+          predecessor: registrationPhaseId,
+          defaultDuration: reviewDuration
+        }
+      ]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          duration: registrationDuration,
+          name: 'Registration',
+          phaseId: registrationPhaseId,
+          scheduledStartDate: registrationStartDate,
+          scheduledEndDate: registrationEndDate
+        },
+        {
+          duration: reviewDuration,
+          name: 'Review',
+          phaseId: reviewPhaseId,
+          predecessor: registrationPhaseId,
+          scheduledStartDate: registrationEndDate,
+          scheduledEndDate: currentReviewEndDate
+        }
+      ],
+      [
+        {
+          phaseId: reviewPhaseId,
+          scheduledEndDate: shortenedReviewEndDate
+        }
+      ],
+      'timeline-template-id',
+      false,
+      {
+        allowActivePhaseShortening: false,
+        preventPhaseShortening: false
+      }
+    )
+
+    updatedPhases[1].scheduledEndDate.should.equal(shortenedReviewEndDate)
+    updatedPhases[1].duration.should.equal(2 * 24 * 60 * 60)
   })
 
   it('rejects active phase end dates before the current date/time', async () => {
@@ -341,12 +570,8 @@ describe('phase helper unit tests', () => {
     const staleDuration = 24 * 60 * 60
 
     stubPhaseLookups(
-      [
-        { id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }
-      ],
-      [
-        { phaseId: registrationPhaseId, defaultDuration: staleDuration }
-      ]
+      [{ id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }],
+      [{ phaseId: registrationPhaseId, defaultDuration: staleDuration }]
     )
 
     try {
@@ -372,9 +597,7 @@ describe('phase helper unit tests', () => {
         { allowActivePhaseShortening: true }
       )
     } catch (e) {
-      e.message.should.equal(
-        'Active phase scheduledEndDate cannot be set before the current date/time.'
-      )
+      e.message.should.equal('Phase scheduledEndDate cannot be set before the current date/time.')
       return
     }
 


### PR DESCRIPTION
What was broken
The previous implementation only allowed Design-track shortening on the currently open phase. QA clarified that Design challenges should allow any incomplete phase to be shortened, and active non-Design updates could still fail when Work sent a stale duration even though the saved scheduled end date did not move earlier.

Root cause
The PM-5378 validation guard was tied to phase.isOpen instead of the active challenge schedule as a whole. The challenge update helper also had a row-id-aware matcher but still used phase definition ids in the main update path, so row-specific timeline edits could be matched incorrectly.

What was changed
Design challenges can now shorten any incomplete phase as long as the requested end date is not before the current date/time. Active non-Design challenges guard every incomplete phase against shortening, while pre-launch non-Design reductions remain allowed. Full challenge updates and direct phase PATCHes both pass the active-challenge guard options, and phase update matching now prefers challenge phase row id before phase definition id.

Any added/updated tests
Bootstrapped the phase helper unit test and added regressions for Design future-phase shortening, active non-Design future-phase rejection, pre-launch non-Design shortening, and stale duration payloads that keep the persisted end date.

Validation:
- pnpm exec mocha test/unit/phase-helper.test.js --exit passed.
- pnpm lint passed.
- pnpm test is blocked in this checkout because DATABASE_URL is not set for Prisma-backed tests.
- pnpm build is unavailable because this package has no build script.
