### PR TITLE
PM-5378: Preserve explicit phase end dates

### DIFF
--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -902,7 +902,20 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
   // Update ChallengePhase
   const currentUserId = String(currentUser.userId);
   data.updatedBy = currentUserId;
-  if (!_.isNil(data.duration)) {
+  if (!_.isNil(data.scheduledEndDate)) {
+    const startInput = !_.isNil(data.scheduledStartDate)
+      ? data.scheduledStartDate
+      : !_.isNil(challengePhase.scheduledStartDate)
+        ? challengePhase.scheduledStartDate
+        : null;
+    if (startInput) {
+      const startDate = new Date(startInput);
+      const endDate = new Date(data.scheduledEndDate);
+      if (!Number.isNaN(startDate.getTime()) && !Number.isNaN(endDate.getTime())) {
+        data.duration = Math.floor((endDate.getTime() - startDate.getTime()) / 1000);
+      }
+    }
+  } else if (!_.isNil(data.duration)) {
     const startInput = !_.isNil(data.scheduledStartDate)
       ? data.scheduledStartDate
       : !_.isNil(challengePhase.scheduledStartDate)

--- a/test/unit/ChallengePhaseService.test.js
+++ b/test/unit/ChallengePhaseService.test.js
@@ -391,6 +391,28 @@ describe('challenge phase service unit tests', () => {
       )
     })
 
+    it('partially update challenge phase - explicit scheduledEndDate wins over stale duration', async function () {
+      this.timeout(50000)
+      const scheduledStartDate = '2025-01-01T00:00:00.000Z'
+      const scheduledEndDate = new Date(
+        new Date(scheduledStartDate).getTime() + 7200 * 1000
+      ).toISOString()
+      const challengePhase = await service.partiallyUpdateChallengePhase(
+        authUser,
+        data.challenge.id,
+        data.challengePhase1Id,
+        {
+          duration: 3600,
+          scheduledEndDate,
+          scheduledStartDate
+        }
+      )
+
+      should.equal(new Date(challengePhase.scheduledStartDate).toISOString(), scheduledStartDate)
+      should.equal(new Date(challengePhase.scheduledEndDate).toISOString(), scheduledEndDate)
+      should.equal(challengePhase.duration, 7200)
+    })
+
     it('partially update challenge phase - closing sets actual end date', async () => {
       await prisma.challengePhase.update({
         where: { id: data.challengePhase1Id },

--- a/test/unit/phase-helper.test.js
+++ b/test/unit/phase-helper.test.js
@@ -103,10 +103,10 @@ describe('phase helper unit tests', () => {
   it('matches launched phase updates by challenge phase id before phase definition id', async () => {
     const sharedPhaseId = 'shared-registration-phase'
     const staleDuration = 120 * 60 * 60
-    const firstPhaseStartDate = '2026-06-15T09:29:45.575Z'
-    const secondPhaseStartDate = '2026-06-15T09:29:45.576Z'
-    const firstPhaseEndDate = '2026-06-20T10:14:45.575Z'
-    const secondPhaseEndDate = '2026-06-20T11:44:45.576Z'
+    const firstPhaseStartDate = '2099-06-15T09:29:45.575Z'
+    const secondPhaseStartDate = '2099-06-15T09:29:45.576Z'
+    const firstPhaseEndDate = '2099-06-20T10:14:45.575Z'
+    const secondPhaseEndDate = '2099-06-20T11:44:45.576Z'
 
     stubPhaseLookups(
       [{ id: sharedPhaseId, name: 'Registration', description: 'Registration phase' }],
@@ -122,7 +122,7 @@ describe('phase helper unit tests', () => {
           phaseId: sharedPhaseId,
           isOpen: true,
           scheduledStartDate: firstPhaseStartDate,
-          scheduledEndDate: '2026-06-20T09:29:45.575Z',
+          scheduledEndDate: '2099-06-20T09:29:45.575Z',
           actualStartDate: firstPhaseStartDate,
           actualEndDate: null
         },
@@ -133,7 +133,7 @@ describe('phase helper unit tests', () => {
           phaseId: sharedPhaseId,
           isOpen: true,
           scheduledStartDate: secondPhaseStartDate,
-          scheduledEndDate: '2026-06-20T09:29:45.576Z',
+          scheduledEndDate: '2099-06-20T09:29:45.576Z',
           actualStartDate: secondPhaseStartDate,
           actualEndDate: null
         }


### PR DESCRIPTION
What was broken
The previous PM-5378 API fix allowed active Design-track phase shortening and blocked active non-Design shortening, but direct phase updates could still send a user-selected scheduledEndDate together with a stale duration. The stale duration could override the explicit end date and make later active challenge edits fail or save an unintended timeline.

Root cause
ChallengePhaseService.partiallyUpdateChallengePhase treated duration as authoritative whenever it was present. That did not match the Work app behavior where concrete user-selected end dates should supersede template or stale duration values.

What was changed
When scheduledEndDate is provided, the API now recalculates duration from the phase start and that explicit end date. It only recalculates scheduledEndDate from duration when no explicit end date is supplied. The existing PM-5378 phase-helper regression fixture was also moved into the future so current-time validation remains deterministic.

Any added/updated tests
Added ChallengePhaseService coverage for explicit scheduledEndDate taking precedence over stale duration. Updated phase-helper PM-5378 regression dates.
