### PR TITLE
PM-5378: Allow unchanged-duration active schedule shifts

### DIFF
--- a/src/common/phase-helper.js
+++ b/src/common/phase-helper.js
@@ -47,6 +47,21 @@ function isDesignTrack(track) {
 }
 
 /**
+ * Resolve the requested scheduled start date from a phase update payload.
+ *
+ * @param {Object} phase existing challenge phase
+ * @param {Object|null|undefined} newPhase phase update payload
+ * @returns {Date|String|undefined} requested scheduled start date, falling back to current start
+ */
+function resolveRequestedScheduledStartDate(phase, newPhase) {
+  if (_.isNil(newPhase) || _.isNil(_.get(newPhase, "scheduledStartDate"))) {
+    return _.get(phase, "scheduledStartDate");
+  }
+
+  return _.get(newPhase, "scheduledStartDate");
+}
+
+/**
  * Resolve the requested scheduled end date from a phase update payload.
  *
  * @param {Object} phase existing challenge phase
@@ -63,16 +78,45 @@ function resolveRequestedScheduledEndDate(phase, newPhase) {
   }
 
   const requestedDuration = _.get(newPhase, "duration");
-  if (_.isNil(requestedDuration) || _.isNil(phase.scheduledStartDate)) {
+  const requestedScheduledStartDate = resolveRequestedScheduledStartDate(phase, newPhase);
+  if (_.isNil(requestedDuration) || _.isNil(requestedScheduledStartDate)) {
     return undefined;
   }
 
-  const scheduledStart = moment(phase.scheduledStartDate);
+  const scheduledStart = moment(requestedScheduledStartDate);
   if (!scheduledStart.isValid()) {
     return undefined;
   }
 
   return scheduledStart.add(requestedDuration, "seconds").toDate().toISOString();
+}
+
+/**
+ * Check whether a requested schedule reduces the phase duration.
+ *
+ * @param {Object} phase existing challenge phase
+ * @param {Date|String|null|undefined} requestedScheduledStartDate requested phase start date
+ * @param {Date|String} requestedScheduledEndDate requested phase end date
+ * @returns {Boolean} true when requested duration is shorter than persisted duration
+ */
+function isPhaseDurationShortened(phase, requestedScheduledStartDate, requestedScheduledEndDate) {
+  const currentStart = moment(phase.scheduledStartDate);
+  const currentEnd = moment(phase.scheduledEndDate);
+  const requestedStart = moment(
+    _.defaultTo(requestedScheduledStartDate, phase.scheduledStartDate)
+  );
+  const requestedEnd = moment(requestedScheduledEndDate);
+
+  if (
+    !currentStart.isValid() ||
+    !currentEnd.isValid() ||
+    !requestedStart.isValid() ||
+    !requestedEnd.isValid()
+  ) {
+    return requestedEnd.isBefore(currentEnd);
+  }
+
+  return requestedEnd.diff(requestedStart, "seconds") < currentEnd.diff(currentStart, "seconds");
 }
 
 /**
@@ -83,6 +127,7 @@ function resolveRequestedScheduledEndDate(phase, newPhase) {
  * @param {Object} options validation options
  * @param {Boolean} options.allowActivePhaseShortening whether Design track phase shortening is allowed
  * @param {Boolean} options.preventPhaseShortening whether shortening is guarded for all incomplete phases
+ * @param {Date|String|null|undefined} options.requestedScheduledStartDate requested scheduled start date
  * @returns {undefined} validates only
  * @throws {BadRequestError} when phase shortening is disallowed or would end in the past
  */
@@ -116,7 +161,14 @@ function validateActivePhaseScheduledEndDateChange(
     phase.isOpen === true ||
     options.allowActivePhaseShortening === true ||
     options.preventPhaseShortening === true;
-  const isShortened = hasCurrentEnd && requestedEnd.isBefore(currentEnd);
+  const isShortened =
+    hasCurrentEnd &&
+    requestedEnd.isBefore(currentEnd) &&
+    isPhaseDurationShortened(
+      phase,
+      options.requestedScheduledStartDate,
+      requestedScheduledEndDate
+    );
 
   if (shouldValidatePhaseEnd && requestedEnd.isBefore(moment())) {
     throw new errors.BadRequestError(
@@ -335,7 +387,10 @@ class ChallengePhaseHelper {
       validateActivePhaseScheduledEndDateChange(
         phase,
         resolveRequestedScheduledEndDate(phase, newPhase),
-        options
+        {
+          ...options,
+          requestedScheduledStartDate: resolveRequestedScheduledStartDate(phase, newPhase),
+        }
       );
       const templatePredecessor = _.get(phaseFromTemplate, "predecessor");
       // Prefer template predecessor only when that phase exists on the challenge, otherwise keep the stored link.

--- a/src/services/ChallengePhaseService.js
+++ b/src/services/ChallengePhaseService.js
@@ -934,9 +934,13 @@ async function partiallyUpdateChallengePhase(currentUser, challengeId, id, data)
   const allowActivePhaseShortening = phaseHelper.isDesignTrack(challenge.track);
   const preventPhaseShortening =
     challenge.status === ChallengeStatusEnum.ACTIVE && !allowActivePhaseShortening;
+  const requestedScheduledStartDate = !_.isNil(data.scheduledStartDate)
+    ? data.scheduledStartDate
+    : challengePhase.scheduledStartDate;
   phaseHelper.validateActivePhaseScheduledEndDateChange(challengePhase, data.scheduledEndDate, {
     allowActivePhaseShortening,
     preventPhaseShortening,
+    requestedScheduledStartDate,
   });
   const dataToUpdate = _.omit(data, "constraints");
   const shouldRefreshPhaseNames =

--- a/test/unit/phase-helper.test.js
+++ b/test/unit/phase-helper.test.js
@@ -391,6 +391,100 @@ describe('phase helper unit tests', () => {
     updatedPhases[0].duration.should.equal(24 * 60 * 60)
   })
 
+  it('allows active non-Design phase start to move earlier when duration is unchanged', async () => {
+    const registrationPhaseId = 'development-registration-phase'
+    const currentRegistrationStartDate = '2099-05-26T05:14:00.000Z'
+    const currentRegistrationEndDate = '2099-05-31T05:14:00.000Z'
+    const requestedRegistrationStartDate = '2099-05-25T05:14:00.000Z'
+    const requestedRegistrationEndDate = '2099-05-30T05:14:00.000Z'
+    const duration = 5 * 24 * 60 * 60
+
+    stubPhaseLookups(
+      [{ id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }],
+      [{ phaseId: registrationPhaseId, defaultDuration: duration }]
+    )
+
+    const updatedPhases = await phaseHelper.populatePhasesForChallengeUpdate(
+      [
+        {
+          duration,
+          isOpen: true,
+          name: 'Registration',
+          phaseId: registrationPhaseId,
+          scheduledStartDate: currentRegistrationStartDate,
+          scheduledEndDate: currentRegistrationEndDate
+        }
+      ],
+      [
+        {
+          duration,
+          phaseId: registrationPhaseId,
+          scheduledStartDate: requestedRegistrationStartDate,
+          scheduledEndDate: requestedRegistrationEndDate
+        }
+      ],
+      'timeline-template-id',
+      false,
+      {
+        allowActivePhaseShortening: false,
+        preventPhaseShortening: true
+      }
+    )
+
+    updatedPhases[0].scheduledStartDate.should.equal(requestedRegistrationStartDate)
+    updatedPhases[0].scheduledEndDate.should.equal(requestedRegistrationEndDate)
+    updatedPhases[0].duration.should.equal(duration)
+  })
+
+  it('rejects active non-Design phase updates that shorten duration after moving start earlier', async () => {
+    const registrationPhaseId = 'development-registration-phase'
+    const currentRegistrationStartDate = '2099-05-26T05:14:00.000Z'
+    const currentRegistrationEndDate = '2099-05-31T05:14:00.000Z'
+    const requestedRegistrationStartDate = '2099-05-25T05:14:00.000Z'
+    const requestedRegistrationEndDate = '2099-05-29T05:14:00.000Z'
+    const duration = 5 * 24 * 60 * 60
+
+    stubPhaseLookups(
+      [{ id: registrationPhaseId, name: 'Registration', description: 'Registration phase' }],
+      [{ phaseId: registrationPhaseId, defaultDuration: duration }]
+    )
+
+    try {
+      await phaseHelper.populatePhasesForChallengeUpdate(
+        [
+          {
+            duration,
+            isOpen: true,
+            name: 'Registration',
+            phaseId: registrationPhaseId,
+            scheduledStartDate: currentRegistrationStartDate,
+            scheduledEndDate: currentRegistrationEndDate
+          }
+        ],
+        [
+          {
+            phaseId: registrationPhaseId,
+            scheduledStartDate: requestedRegistrationStartDate,
+            scheduledEndDate: requestedRegistrationEndDate
+          }
+        ],
+        'timeline-template-id',
+        false,
+        {
+          allowActivePhaseShortening: false,
+          preventPhaseShortening: true
+        }
+      )
+    } catch (e) {
+      e.message.should.equal(
+        'Challenge phase schedules can only be shortened for Design track challenges.'
+      )
+      return
+    }
+
+    throw new Error('should not reach here')
+  })
+
   it('rejects active phase shortening for non-Design tracks', async () => {
     const registrationPhaseId = 'development-registration-phase'
     const staleDuration = 5 * 24 * 60 * 60


### PR DESCRIPTION
What was broken
Active Development challenge edits could still be rejected with the Design-only shortening error when a user moved a phase start earlier, or switched the challenge start to Immediately, while keeping the phase duration unchanged.

Root cause
The active phase schedule guard compared the requested scheduled end date only against the persisted end date. When the start date also moved earlier, an unchanged-duration phase had an earlier end date and was incorrectly classified as a shortened phase.

What was changed
The phase helper now resolves the requested scheduled start date before validation and treats a non-Design active update as shortening only when the requested phase duration is actually reduced. The direct phase PATCH path now passes the same requested start-date context to the shared validation.

Any added/updated tests
Added phase-helper regression coverage for allowing active non-Design phase start shifts when duration is unchanged, and for still rejecting active non-Design updates that reduce duration after moving the start earlier.

Validation
pnpm exec mocha --exit test/unit/phase-helper.test.js passed.
pnpm lint passed.
pnpm build is unavailable because challenge-api-v6 has no build command.
pnpm test is blocked locally by missing DATABASE_URL for Prisma-backed unit suites; the new phase-helper tests pass within that run before the command exits on the environment issue.
