### PR TITLE
PM-5761: Count every design submission concept

### DIFF
--- a/src/services/ChallengeService.ts
+++ b/src/services/ChallengeService.ts
@@ -100,17 +100,24 @@ function isCancelledChallengeStatus(status) {
 /**
  * Loads submission counters for challenge responses from the review submission table.
  *
- * Community app badges show the number of members with submissions, not the
- * number of attempts, so repeated uploads by the same member are counted once.
+ * Community app badges normally show the number of members with submissions,
+ * so repeated uploads by the same member are counted once. Design challenges
+ * count every submission because each upload can be a unique concept.
  *
  * @param {Array<String>} challengeIds challenge identifiers to count submissions for
+ * @param {Array<String>} designChallengeIds Design challenge identifiers that count every upload
  * @returns {Promise<Map<String, { numOfSubmissions: Number, numOfCheckpointSubmissions: Number }>>}
  * counts keyed by challenge id
  * @throws {Error} when the review database query fails
  */
-async function getLatestSubmissionCountsByChallenge(challengeIds) {
+async function getLatestSubmissionCountsByChallenge(challengeIds, designChallengeIds = []) {
   const ids = _.uniq(
     (challengeIds || [])
+      .map((challengeId) => _.toString(challengeId).trim())
+      .filter((challengeId) => !!challengeId),
+  );
+  const designIds = _.uniq(
+    (designChallengeIds || [])
       .map((challengeId) => _.toString(challengeId).trim())
       .filter((challengeId) => !!challengeId),
   );
@@ -124,16 +131,22 @@ async function getLatestSubmissionCountsByChallenge(challengeIds) {
   const submissionTable = reviewSchema
     ? Prisma.raw(`"${reviewSchema.replace(/"/g, '""')}"."submission"`)
     : Prisma.raw('"submission"');
+  const submissionIdentity = designIds.length
+    ? Prisma.sql`CASE
+        WHEN "challengeId" IN (${Prisma.join(designIds)}) THEN "id"
+        ELSE "memberId"
+      END`
+    : Prisma.sql`"memberId"`;
   const reviewClient = getReviewClient();
 
   const rows = await reviewClient.$queryRaw`
     SELECT
       "challengeId",
       COUNT(DISTINCT CASE
-        WHEN "type"::text = ${CHECKPOINT_SUBMISSION_TYPE} THEN "memberId"
+        WHEN "type"::text = ${CHECKPOINT_SUBMISSION_TYPE} THEN ${submissionIdentity}
       END)::int AS "numOfCheckpointSubmissions",
       COUNT(DISTINCT CASE
-        WHEN "type"::text <> ${CHECKPOINT_SUBMISSION_TYPE} THEN "memberId"
+        WHEN "type"::text <> ${CHECKPOINT_SUBMISSION_TYPE} THEN ${submissionIdentity}
       END)::int AS "numOfSubmissions"
     FROM ${submissionTable}
     WHERE "challengeId" IN (${Prisma.join(ids)})
@@ -152,7 +165,11 @@ async function getLatestSubmissionCountsByChallenge(challengeIds) {
 }
 
 /**
- * Applies latest-member submission counts to challenge records before response conversion.
+ * Applies submission counts to challenge records before response conversion.
+ *
+ * Design challenges count every submission as a separate concept. Other tracks
+ * count distinct submitting members so replacement attempts do not inflate the
+ * displayed total.
  *
  * If the review query succeeds, challenges without submission rows are reset to
  * zero so stale stored counters are not shown. If the query cannot run, callers
@@ -169,8 +186,12 @@ async function applyLatestSubmissionCounts(challenges) {
 
   let countsByChallenge;
   try {
+    const designChallengeIds = records
+      .filter((challenge) => phaseHelper.isDesignTrack(challenge.track))
+      .map((challenge) => challenge.id);
     countsByChallenge = await getLatestSubmissionCountsByChallenge(
       records.map((challenge) => challenge.id),
+      designChallengeIds,
     );
   } catch (err) {
     logger.warn(`Failed to load latest submission counts: ${err.message}`);

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -704,6 +704,55 @@ describe("challenge service unit tests", () => {
       }
     });
 
+    it("counts every Design submission as a separate concept", async () => {
+      const challengeId = data.challenge.id;
+      const originalTrack = data.challengeTrack.track;
+      await prisma.challengeTrack.update({
+        where: { id: data.challenge.trackId },
+        data: { track: "DESIGN" },
+      });
+
+      try {
+        await reviewClient.$executeRawUnsafe(`
+          INSERT INTO ${submissionTableName}
+            ("id", "challengeId", "memberId", "type", "status", "submittedDate")
+          VALUES
+            ('pm5761a1', '${challengeId}', 'member-1', 'CONTEST_SUBMISSION', 'ACTIVE', '2026-01-01T00:00:00Z'),
+            ('pm5761a2', '${challengeId}', 'member-1', 'CONTEST_SUBMISSION', 'ACTIVE', '2026-01-02T00:00:00Z'),
+            ('pm5761a3', '${challengeId}', 'member-1', 'CONTEST_SUBMISSION', 'ACTIVE', '2026-01-03T00:00:00Z'),
+            ('pm5761c1', '${challengeId}', 'member-1', 'CHECKPOINT_SUBMISSION', 'ACTIVE', '2026-01-04T00:00:00Z'),
+            ('pm5761c2', '${challengeId}', 'member-1', 'CHECKPOINT_SUBMISSION', 'ACTIVE', '2026-01-05T00:00:00Z')
+        `);
+
+        const detail = await service.getChallenge({ isMachine: true }, challengeId);
+        should.equal(detail.numOfSubmissions, 3);
+        should.equal(detail.numOfCheckpointSubmissions, 2);
+
+        const listing = await service.searchChallenges(
+          { isMachine: true },
+          {
+            id: challengeId,
+            page: 1,
+            perPage: 10,
+          },
+        );
+        should.equal(listing.result.length, 1);
+        should.equal(listing.result[0].numOfSubmissions, 3);
+        should.equal(listing.result[0].numOfCheckpointSubmissions, 2);
+      } finally {
+        try {
+          await reviewClient.$executeRawUnsafe(
+            `DELETE FROM ${submissionTableName} WHERE "challengeId" = '${challengeId}'`,
+          );
+        } finally {
+          await prisma.challengeTrack.update({
+            where: { id: data.challenge.trackId },
+            data: { track: originalTrack },
+          });
+        }
+      }
+    });
+
     it("get challenge preserves billing for project write users", async () => {
       const originalUserHasProjectWriteAccess = helper.userHasProjectWriteAccess;
 


### PR DESCRIPTION
## What was broken

Challenge detail and listing responses counted multiple Design concepts from one member as a single submission. Community App renders those API counters directly, so five concepts could appear as one submission.

## Root cause

Challenge API recomputed both `numOfSubmissions` and `numOfCheckpointSubmissions` with `memberId` as the distinct identity for every track. That is correct for replacement attempts on non-Design challenges, but Design uploads can represent separate concepts.

## What was changed

- Use submission ID as the distinct counter identity for Design challenges.
- Preserve member-based counting for all other tracks.
- Apply the Design rule to both checkpoint and non-checkpoint submissions.

## Any added/updated tests

- Added a regression test with five Design concepts from one member, covering both final and checkpoint counters in challenge detail and listing responses.
- Preserved and reran the existing Development regression to verify repeated attempts still count once per member.
- `pnpm test -- --grep 'returns latest-member submission counters|counts every Design submission'`, `pnpm lint`, and `pnpm build` pass.

The full `pnpm test` command was also run. It reaches and passes the PM-5761 tests, but the current `develop` baseline has unrelated failures across legacy validation assertions and test database setup.
