### PR TITLE
PM-5754: update winning download metadata docs

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2588,8 +2588,7 @@ definitions:
               description: >-
                 Metadata name. Use submission_type to override the challenge submission flow. Use
                 allowAllRegistrantsToDownloadWinningSubmissions to let all registrants download
-                winning submissions after the challenge ends. For Design challenges,
-                submissionsViewable must also be true.
+                winning submissions after the challenge ends.
             value:
               type: string
               description: >-
@@ -2881,8 +2880,7 @@ definitions:
               description: >-
                 Metadata name. Use submission_type to override the challenge submission flow. Use
                 allowAllRegistrantsToDownloadWinningSubmissions to let all registrants download
-                winning submissions after the challenge ends. For Design challenges,
-                submissionsViewable must also be true.
+                winning submissions after the challenge ends.
             value:
               type: string
               description: >-
@@ -3059,8 +3057,7 @@ definitions:
               description: >-
                 Metadata name. Use submission_type to override the challenge submission flow. Use
                 allowAllRegistrantsToDownloadWinningSubmissions to let all registrants download
-                winning submissions after the challenge ends. For Design challenges,
-                submissionsViewable must also be true.
+                winning submissions after the challenge ends.
             value:
               type: string
               description: >-
@@ -3282,8 +3279,7 @@ definitions:
               description: >-
                 Metadata name. Use submission_type to override the challenge submission flow. Use
                 allowAllRegistrantsToDownloadWinningSubmissions to let all registrants download
-                winning submissions after the challenge ends. For Design challenges,
-                submissionsViewable must also be true.
+                winning submissions after the challenge ends.
             value:
               type: string
               description: >-


### PR DESCRIPTION
## What was broken

The challenge API schema described submissionsViewable as an additional prerequisite for Design winning-submission downloads.

## Root cause

Swagger documentation still reflected the obsolete Design-specific authorization gate.

## What was changed

Removed the obsolete submissionsViewable prerequisite from the winning-download metadata descriptions in create, update, patch, and response schemas.

## Any added/updated tests

No tests were changed because this is a documentation-only contract correction. The focused metadata/helper suite passes 10 of 10 tests, and `pnpm lint` plus `pnpm build` pass. The required full suite was also run against the local test database: 132 tests passed and 66 existing unrelated tests failed.
