### PR TITLE
PM-5775: expose active checkpoint winners

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2681,6 +2681,7 @@ definitions:
           - placement
       checkpointWinners:
         type: array
+        description: Checkpoint winners are returned after Checkpoint Review closes, including while the challenge is active.
         items:
           properties:
             userId:

--- a/src/services/ChallengeService.ts
+++ b/src/services/ChallengeService.ts
@@ -845,8 +845,9 @@ const challengeDomain = {
 const phaseAdvancer = new PhaseAdvancer(challengeDomain);
 
 const REVIEW_STATUS_BLOCKING = Object.freeze(["IN_PROGRESS", "COMPLETED"]);
+const CHECKPOINT_REVIEW_PHASE_NAME = "checkpoint review";
 const REVIEW_PHASE_NAMES = Object.freeze([
-  "checkpoint review",
+  CHECKPOINT_REVIEW_PHASE_NAME,
   "checkpoint screening",
   "screening",
   "review",
@@ -859,6 +860,33 @@ const AI_REVIEW_PHASE_NAME = "ai review";
 
 function normalizePhaseNameForComparison(phaseName) {
   return _.toString(phaseName).replace(/-/g, " ").trim().toLowerCase();
+}
+
+/**
+ * Determines whether checkpoint winners are ready to be included in challenge responses.
+ * Detail and search response sanitization use this after Checkpoint Review has closed,
+ * while completed challenges preserve their existing winner visibility.
+ *
+ * @param {Object} challenge challenge data containing status and phase state
+ * @returns {Boolean} true when assigned checkpoint winners may be returned
+ * @throws {Error} this function does not throw
+ */
+function shouldExposeCheckpointWinners(challenge) {
+  if (challenge.status === ChallengeStatusEnum.COMPLETED) {
+    return true;
+  }
+  if (challenge.status !== ChallengeStatusEnum.ACTIVE) {
+    return false;
+  }
+
+  return _.some(
+    challenge.phases,
+    (phase) =>
+      normalizePhaseNameForComparison(phase.name) === CHECKPOINT_REVIEW_PHASE_NAME &&
+      phase.isOpen !== true &&
+      !_.isNil(phase.actualStartDate) &&
+      !_.isNil(phase.actualEndDate),
+  );
 }
 
 function extractSubmissionId(submission) {
@@ -2316,6 +2344,8 @@ async function searchChallenges(currentUser, criteria) {
   result.forEach((challenge) => {
     if (challenge.status !== ChallengeStatusEnum.COMPLETED) {
       _.unset(challenge, "winners");
+    }
+    if (!shouldExposeCheckpointWinners(challenge)) {
       _.unset(challenge, "checkpointWinners");
     }
     if (!_hasAdminRole && !_.get(currentUser, "isMachine", false)) {
@@ -3041,8 +3071,14 @@ async function getChallenge(currentUser, id, checkIfExists?: any) {
   }
 
   if (challenge.status !== ChallengeStatusEnum.COMPLETED) {
-    _.unset(challenge, "winners");
-    _.unset(challenge, "checkpointWinners");
+    if (shouldExposeCheckpointWinners(challenge)) {
+      challenge.winners = _.filter(
+        challenge.winners,
+        (winner) => winner.type === PrizeSetTypeEnum.CHECKPOINT,
+      );
+    } else {
+      _.unset(challenge, "winners");
+    }
   }
 
   // TODO: in the long run we wanna do a finer grained filtering of the payments

--- a/test/unit/ChallengeService.test.js
+++ b/test/unit/ChallengeService.test.js
@@ -652,6 +652,115 @@ describe("challenge service unit tests", () => {
       should.equal(result.numOfRegistrants, 0);
     });
 
+    it("returns checkpoint winners after checkpoint review closes while keeping placement winners hidden", async () => {
+      const challengeId = data.challenge.id;
+      const checkpointPhase = await prisma.challengePhase.findFirstOrThrow({
+        where: { challengeId },
+      });
+      const originalPhase = _.pick(checkpointPhase, [
+        "name",
+        "isOpen",
+        "actualStartDate",
+        "actualEndDate",
+      ]);
+      const phaseStartDate = new Date(Date.now() - 60_000);
+      await prisma.challenge.update({
+        where: { id: challengeId },
+        data: { status: ChallengeStatusEnum.ACTIVE },
+      });
+      await prisma.challengePhase.update({
+        where: { id: checkpointPhase.id },
+        data: {
+          name: "Checkpoint Review",
+          isOpen: true,
+          actualStartDate: phaseStartDate,
+          actualEndDate: null,
+        },
+      });
+      await prisma.challengeWinner.createMany({
+        data: [
+          {
+            challengeId,
+            userId: 123,
+            handle: "checkpoint-winner",
+            placement: 1,
+            type: PrizeSetTypeEnum.CHECKPOINT,
+            createdBy: "test",
+            updatedBy: "test",
+          },
+          {
+            challengeId,
+            userId: 456,
+            handle: "placement-winner",
+            placement: 1,
+            type: PrizeSetTypeEnum.PLACEMENT,
+            createdBy: "test",
+            updatedBy: "test",
+          },
+        ],
+      });
+
+      try {
+        const openPhaseDetail = await service.getChallenge({ isMachine: true }, challengeId);
+        should.equal(_.isUndefined(openPhaseDetail.checkpointWinners), true);
+        openPhaseDetail.winners.should.deep.equal([]);
+
+        const openPhaseListing = await service.searchChallenges(
+          { isMachine: true },
+          {
+            id: challengeId,
+            page: 1,
+            perPage: 10,
+          },
+        );
+        should.equal(openPhaseListing.result.length, 1);
+        should.equal(_.isUndefined(openPhaseListing.result[0].checkpointWinners), true);
+        should.equal(_.isUndefined(openPhaseListing.result[0].winners), true);
+
+        await prisma.challengePhase.update({
+          where: { id: checkpointPhase.id },
+          data: {
+            isOpen: false,
+            actualEndDate: new Date(),
+          },
+        });
+
+        const closedPhaseDetail = await service.getChallenge({ isMachine: true }, challengeId);
+        closedPhaseDetail.checkpointWinners.should.deep.equal([
+          {
+            userId: 123,
+            handle: "checkpoint-winner",
+            placement: 1,
+          },
+        ]);
+        closedPhaseDetail.winners.should.deep.equal([]);
+
+        const closedPhaseListing = await service.searchChallenges(
+          { isMachine: true },
+          {
+            id: challengeId,
+            page: 1,
+            perPage: 10,
+          },
+        );
+        should.equal(closedPhaseListing.result.length, 1);
+        closedPhaseListing.result[0].checkpointWinners.should.deep.equal(
+          closedPhaseDetail.checkpointWinners,
+        );
+        should.equal(_.isUndefined(closedPhaseListing.result[0].winners), true);
+      } finally {
+        await prisma.challengeWinner.deleteMany({ where: { challengeId } });
+        await prisma.challengePhase.update({
+          where: { id: checkpointPhase.id },
+          data: originalPhase,
+        });
+        await prisma.challenge.update({
+          where: { id: challengeId },
+          data: { status: ChallengeStatusEnum.COMPLETED },
+        });
+      }
+    });
+
     it("returns latest-member submission counters for challenge detail and listing", async () => {
       const challengeId = data.challenge.id;
       await prisma.challenge.update({


### PR DESCRIPTION
## What was broken

Checkpoint winners assigned during an active challenge were hidden until the entire challenge completed, so the Review app could not tell a member that they had won a checkpoint prize.

## Root cause

Challenge response sanitization treated checkpoint winners like final-placement winners and removed both from every non-completed challenge.

## What was changed

- Return checkpoint winners for an active challenge only after Checkpoint Review has opened and closed.
- Continue hiding final-placement winners until challenge completion.
- Apply the same visibility rule to challenge detail and listing responses.
- Document the checkpoint-winner response timing in Swagger.

## Any added/updated tests

- Added service coverage for active challenges while Checkpoint Review is open and after it closes.
- Verified detail and listing responses expose checkpoint winners only after closure.
- Verified placement winners remain hidden throughout the active challenge.

## Validation

- `NODE_ENV=test pnpm exec mocha --require ts-node/register/transpile-only test/unit/ChallengeService.test.js --grep "returns checkpoint winners after checkpoint review closes" --timeout 30000 --exit` — passed.
- `pnpm lint` — passed.
- `pnpm build` — passed.
- The repository-wide `pnpm test` still reports 143 pre-existing failures caused by unavailable local mock services and existing harness/schema expectation issues; the PM-5775 regression test passes independently.

## Paired change

Paired with [Platform UI PR #2082](https://github.com/topcoder-platform/platform-ui/pull/2082), which renders the checkpoint-winner indicator and tooltip.
